### PR TITLE
Persist Token account indexes via plugin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 bs58 = "0.4.0"
+bytemuck = "1.7.2"
 chrono = { version = "0.4.11", features = ["serde"] }
 crossbeam-channel = "0.5"
 log = "0.4.14"

--- a/scripts/create_schema.sql
+++ b/scripts/create_schema.sql
@@ -177,7 +177,8 @@ CREATE TABLE block (
 -- The table storing spl token owner to account indexes
 CREATE TABLE spl_token_owner_index (
     owner_key BYTEA NOT NULL,
-    inner_key BYTEA NOT NULL
+    inner_key BYTEA NOT NULL,
+    slot BIGINT NOT NULL
 );
 
 CREATE INDEX spl_token_owner_index_owner_key ON spl_token_owner_index (owner_key);
@@ -186,7 +187,8 @@ CREATE UNIQUE INDEX spl_token_owner_index_owner_pair ON spl_token_owner_index (o
 -- The table storing spl mint to account indexes
 CREATE TABLE spl_token_mint_index (
     mint_key BYTEA NOT NULL,
-    inner_key BYTEA NOT NULL
+    inner_key BYTEA NOT NULL,
+    slot BIGINT NOT NULL
 );
 
 CREATE INDEX spl_token_mint_index_mint_key ON spl_token_mint_index (mint_key);

--- a/scripts/create_schema.sql
+++ b/scripts/create_schema.sql
@@ -181,6 +181,7 @@ CREATE TABLE spl_token_owner_index (
 );
 
 CREATE INDEX spl_token_owner_index_owner_key ON spl_token_owner_index (owner_key);
+CREATE UNIQUE INDEX spl_token_owner_index_owner_pair ON spl_token_owner_index (owner_key, inner_key);
 
 -- The table storing spl mint to account indexes
 CREATE TABLE spl_token_mint_index (
@@ -189,6 +190,7 @@ CREATE TABLE spl_token_mint_index (
 );
 
 CREATE INDEX spl_token_mint_index_mint_key ON spl_token_mint_index (mint_key);
+CREATE UNIQUE INDEX spl_token_mint_index_mint_pair ON spl_token_owner_index (mint_key, inner_key);
 
 /**
  * The following is for keeping historical data for accounts and is not required for plugin to work.

--- a/scripts/create_schema.sql
+++ b/scripts/create_schema.sql
@@ -190,7 +190,7 @@ CREATE TABLE spl_token_mint_index (
 );
 
 CREATE INDEX spl_token_mint_index_mint_key ON spl_token_mint_index (mint_key);
-CREATE UNIQUE INDEX spl_token_mint_index_mint_pair ON spl_token_owner_index (mint_key, inner_key);
+CREATE UNIQUE INDEX spl_token_mint_index_mint_pair ON spl_token_mint_index (mint_key, inner_key);
 
 /**
  * The following is for keeping historical data for accounts and is not required for plugin to work.

--- a/scripts/create_schema.sql
+++ b/scripts/create_schema.sql
@@ -177,22 +177,22 @@ CREATE TABLE block (
 -- The table storing spl token owner to account indexes
 CREATE TABLE spl_token_owner_index (
     owner_key BYTEA NOT NULL,
-    inner_key BYTEA NOT NULL,
+    account_key BYTEA NOT NULL,
     slot BIGINT NOT NULL
 );
 
 CREATE INDEX spl_token_owner_index_owner_key ON spl_token_owner_index (owner_key);
-CREATE UNIQUE INDEX spl_token_owner_index_owner_pair ON spl_token_owner_index (owner_key, inner_key);
+CREATE UNIQUE INDEX spl_token_owner_index_owner_pair ON spl_token_owner_index (owner_key, account_key);
 
 -- The table storing spl mint to account indexes
 CREATE TABLE spl_token_mint_index (
     mint_key BYTEA NOT NULL,
-    inner_key BYTEA NOT NULL,
+    account_key BYTEA NOT NULL,
     slot BIGINT NOT NULL
 );
 
 CREATE INDEX spl_token_mint_index_mint_key ON spl_token_mint_index (mint_key);
-CREATE UNIQUE INDEX spl_token_mint_index_mint_pair ON spl_token_mint_index (mint_key, inner_key);
+CREATE UNIQUE INDEX spl_token_mint_index_mint_pair ON spl_token_mint_index (mint_key, account_key);
 
 /**
  * The following is for keeping historical data for accounts and is not required for plugin to work.
@@ -211,6 +211,8 @@ CREATE TABLE account_audit (
 );
 
 CREATE INDEX account_audit_account_key ON  account_audit (pubkey, write_version);
+
+CREATE INDEX account_audit_pubkey_slot ON account_audit (pubkey, slot);
 
 CREATE FUNCTION audit_account_update() RETURNS trigger AS $audit_account_update$
     BEGIN

--- a/scripts/postgresql.conf
+++ b/scripts/postgresql.conf
@@ -411,7 +411,7 @@ max_wal_senders = 0		# max number of walsender processes
 #geqo_threshold = 12
 #geqo_effort = 5			# range 1-10
 #geqo_pool_size = 0			# selects default based on effort
-#geqo_generations = 0			# selects default based on effort
+#geqo_genericerations = 0			# selects default based on effort
 #geqo_selection_bias = 2.0		# range 1.5-2.0
 #geqo_seed = 0.0			# range 0.0-1.0
 
@@ -424,7 +424,7 @@ max_wal_senders = 0		# max number of walsender processes
 #jit = on				# allow JIT compilation
 #join_collapse_limit = 8		# 1 disables collapsing of explicit
 					# JOIN clauses
-#plan_cache_mode = auto			# auto, force_generic_plan or
+#plan_cache_mode = auto			# auto, force_genericeric_plan or
 					# force_custom_plan
 
 

--- a/scripts/postgresql.conf
+++ b/scripts/postgresql.conf
@@ -411,7 +411,7 @@ max_wal_senders = 0		# max number of walsender processes
 #geqo_threshold = 12
 #geqo_effort = 5			# range 1-10
 #geqo_pool_size = 0			# selects default based on effort
-#geqo_genericerations = 0			# selects default based on effort
+#geqo_generations = 0			# selects default based on effort
 #geqo_selection_bias = 2.0		# range 1.5-2.0
 #geqo_seed = 0.0			# range 0.0-1.0
 
@@ -424,7 +424,7 @@ max_wal_senders = 0		# max number of walsender processes
 #jit = on				# allow JIT compilation
 #join_collapse_limit = 8		# 1 disables collapsing of explicit
 					# JOIN clauses
-#plan_cache_mode = auto			# auto, force_genericeric_plan or
+#plan_cache_mode = auto			# auto, force_generic_plan or
 					# force_custom_plan
 
 

--- a/src/accountsdb_plugin_postgres.rs
+++ b/src/accountsdb_plugin_postgres.rs
@@ -32,7 +32,7 @@ impl std::fmt::Debug for AccountsDbPluginPostgres {
     }
 }
 
-/// The Configurqation for the PostgreSQL plugin
+/// The Configuration for the PostgreSQL plugin
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct AccountsDbPluginPostgresConfig {
     /// The host name or IP of the PostgreSQL server

--- a/src/accountsdb_plugin_postgres.rs
+++ b/src/accountsdb_plugin_postgres.rs
@@ -32,21 +32,55 @@ impl std::fmt::Debug for AccountsDbPluginPostgres {
     }
 }
 
+/// The Configurqation for the PostgreSQL plugin
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct AccountsDbPluginPostgresConfig {
+    /// The host name or IP of the PostgreSQL server
     pub host: Option<String>,
+
+    /// The user name of the PostgreSQL server.
     pub user: Option<String>,
+
+    /// The port number of the PostgreSQL database, the default is 5432
     pub port: Option<u16>,
+
+    /// The connection string of PostgreSQL database, if this is set
+    /// `host`, `user` and `port` will be ignored.
     pub connection_str: Option<String>,
+
+    /// Controls the number of threads establishing connections to
+    /// the PostgreSQL server. The default is 10.
     pub threads: Option<usize>,
+
+    /// Controls the batch size when bulk loading accounts.
+    /// The default is 10.
     pub batch_size: Option<usize>,
+
+    /// Controls if to panic the validator in case of errors
+    /// writing to PostgreSQL server. The default is false
     pub panic_on_db_errors: Option<bool>,
+
     /// Indicates if to store historical data for accounts
     pub store_account_historical_data: Option<bool>,
+
+    /// Controls if to use SSL based connection to the database server.
+    /// The default is false
     pub use_ssl: Option<bool>,
+
+    /// Specify the path to PostgreSQL server's certificate file
     pub server_ca: Option<String>,
+
+    /// Specify the path to the local client's certificate file
     pub client_cert: Option<String>,
+
+    /// Specify the path to the local client's private PEM key file.
     pub client_key: Option<String>,
+
+    /// Controls if to index the token owners. The default is false
+    pub index_token_owner: Option<bool>,
+
+    /// Controls if to index the token mints. The default is false
+    pub index_token_mint: Option<bool>,
 }
 
 #[derive(Error, Debug)]

--- a/src/accountsdb_plugin_postgres.rs
+++ b/src/accountsdb_plugin_postgres.rs
@@ -56,14 +56,14 @@ pub struct AccountsDbPluginPostgresConfig {
     /// The default is 10.
     pub batch_size: Option<usize>,
 
-    /// Controls if to panic the validator in case of errors
+    /// Controls whether to panic the validator in case of errors
     /// writing to PostgreSQL server. The default is false
     pub panic_on_db_errors: Option<bool>,
 
-    /// Indicates if to store historical data for accounts
+    /// Indicates whether to store historical data for accounts
     pub store_account_historical_data: Option<bool>,
 
-    /// Controls if to use SSL based connection to the database server.
+    /// Controls whether to use SSL based connection to the database server.
     /// The default is false
     pub use_ssl: Option<bool>,
 
@@ -76,10 +76,10 @@ pub struct AccountsDbPluginPostgresConfig {
     /// Specify the path to the local client's private PEM key file.
     pub client_key: Option<String>,
 
-    /// Controls if to index the token owners. The default is false
+    /// Controls whether to index the token owners. The default is false
     pub index_token_owner: Option<bool>,
 
-    /// Controls if to index the token mints. The default is false
+    /// Controls whetherf to index the token mints. The default is false
     pub index_token_mint: Option<bool>,
 }
 

--- a/src/inline_spl_token.rs
+++ b/src/inline_spl_token.rs
@@ -8,18 +8,6 @@ pub(crate) mod new_token_program {
     solana_sdk::declare_id!("nTok2oJvx1CgbYA2SznfJLmnKLEL6sYdh2ypZms2nhm");
 }
 
-/*
-    spl_token::state::Account {
-        mint: Pubkey,
-        owner: Pubkey,
-        amount: u64,
-        delegate: COption<Pubkey>,
-        state: AccountState,
-        is_native: COption<u64>,
-        delegated_amount: u64,
-        close_authority: COption<Pubkey>,
-    }
-*/
 pub const SPL_TOKEN_ACCOUNT_MINT_OFFSET: usize = 0;
 pub const SPL_TOKEN_ACCOUNT_OWNER_OFFSET: usize = 32;
 const SPL_TOKEN_ACCOUNT_LENGTH: usize = 165;

--- a/src/inline_spl_token.rs
+++ b/src/inline_spl_token.rs
@@ -8,6 +8,20 @@ pub(crate) mod new_token_program {
     solana_sdk::declare_id!("nTok2oJvx1CgbYA2SznfJLmnKLEL6sYdh2ypZms2nhm");
 }
 
+/*
+    /// The SPL token definition -- we care about only the mint and owner fields for now.
+    /// at offset 0 and 32 respectively.
+    spl_token::state::Account {
+        mint: Pubkey,
+        owner: Pubkey,
+        amount: u64,
+        delegate: COption<Pubkey>,
+        state: AccountState,
+        is_native: COption<u64>,
+        delegated_amount: u64,
+        close_authority: COption<Pubkey>,
+    }
+*/
 pub const SPL_TOKEN_ACCOUNT_MINT_OFFSET: usize = 0;
 pub const SPL_TOKEN_ACCOUNT_OWNER_OFFSET: usize = 32;
 const SPL_TOKEN_ACCOUNT_LENGTH: usize = 165;

--- a/src/inline_spl_token.rs
+++ b/src/inline_spl_token.rs
@@ -1,0 +1,92 @@
+/// Partial SPL Token declarations inlined to avoid an external dependency on the spl-token crate
+/// Copied from solana-runtime
+use solana_sdk::pubkey::{Pubkey, PUBKEY_BYTES};
+
+solana_sdk::declare_id!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
+
+pub(crate) mod new_token_program {
+    solana_sdk::declare_id!("nTok2oJvx1CgbYA2SznfJLmnKLEL6sYdh2ypZms2nhm");
+}
+
+/*
+    spl_token::state::Account {
+        mint: Pubkey,
+        owner: Pubkey,
+        amount: u64,
+        delegate: COption<Pubkey>,
+        state: AccountState,
+        is_native: COption<u64>,
+        delegated_amount: u64,
+        close_authority: COption<Pubkey>,
+    }
+*/
+pub const SPL_TOKEN_ACCOUNT_MINT_OFFSET: usize = 0;
+pub const SPL_TOKEN_ACCOUNT_OWNER_OFFSET: usize = 32;
+const SPL_TOKEN_ACCOUNT_LENGTH: usize = 165;
+
+pub(crate) trait GenericTokenAccount {
+    fn valid_account_data(account_data: &[u8]) -> bool;
+
+    // Call after account length has already been verified
+    fn unpack_account_owner_unchecked(account_data: &[u8]) -> &Pubkey {
+        Self::unpack_pubkey_unchecked(account_data, SPL_TOKEN_ACCOUNT_OWNER_OFFSET)
+    }
+
+    // Call after account length has already been verified
+    fn unpack_account_mint_unchecked(account_data: &[u8]) -> &Pubkey {
+        Self::unpack_pubkey_unchecked(account_data, SPL_TOKEN_ACCOUNT_MINT_OFFSET)
+    }
+
+    // Call after account length has already been verified
+    fn unpack_pubkey_unchecked(account_data: &[u8], offset: usize) -> &Pubkey {
+        bytemuck::from_bytes(&account_data[offset..offset + PUBKEY_BYTES])
+    }
+
+    fn unpack_account_owner(account_data: &[u8]) -> Option<&Pubkey> {
+        if Self::valid_account_data(account_data) {
+            Some(Self::unpack_account_owner_unchecked(account_data))
+        } else {
+            None
+        }
+    }
+
+    fn unpack_account_mint(account_data: &[u8]) -> Option<&Pubkey> {
+        if Self::valid_account_data(account_data) {
+            Some(Self::unpack_account_mint_unchecked(account_data))
+        } else {
+            None
+        }
+    }
+}
+
+pub struct Account;
+impl Account {
+    pub fn get_packed_len() -> usize {
+        SPL_TOKEN_ACCOUNT_LENGTH
+    }
+}
+
+impl GenericTokenAccount for Account {
+    fn valid_account_data(account_data: &[u8]) -> bool {
+        account_data.len() == SPL_TOKEN_ACCOUNT_LENGTH
+    }
+}
+
+pub mod native_mint {
+    solana_sdk::declare_id!("So11111111111111111111111111111111111111112");
+
+    /*
+        Mint {
+            mint_authority: COption::None,
+            supply: 0,
+            decimals: 9,
+            is_initialized: true,
+            freeze_authority: COption::None,
+        }
+    */
+    pub const ACCOUNT_DATA: [u8; 82] = [
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 9, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    ];
+}

--- a/src/inline_spl_token_2022.rs
+++ b/src/inline_spl_token_2022.rs
@@ -1,0 +1,19 @@
+/// Partial SPL Token declarations inlined to avoid an external dependency on the spl-token-2022 crate
+/// Copied from solana-runtime
+use crate::inline_spl_token::{self, GenericTokenAccount};
+
+solana_sdk::declare_id!("TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb");
+
+// `spl_token_program_2022::extension::AccountType::Account` ordinal value
+const ACCOUNTTYPE_ACCOUNT: u8 = 2;
+
+pub struct Account;
+impl GenericTokenAccount for Account {
+    fn valid_account_data(account_data: &[u8]) -> bool {
+        inline_spl_token::Account::valid_account_data(account_data)
+            || ACCOUNTTYPE_ACCOUNT
+                == *account_data
+                    .get(inline_spl_token::Account::get_packed_len())
+                    .unwrap_or(&0)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,6 @@
 pub mod accounts_selector;
 pub mod accountsdb_plugin_postgres;
+pub mod inline_spl_token;
+pub mod inline_spl_token_2022;
 pub mod postgres_client;
 pub mod transaction_selector;

--- a/src/postgres_client.rs
+++ b/src/postgres_client.rs
@@ -10,7 +10,7 @@ use {
         accountsdb_plugin_postgres::{
             AccountsDbPluginPostgresConfig, AccountsDbPluginPostgresError,
         },
-        postgres_client::postgres_client_account_index::TokenSecondaryIndex,
+        postgres_client::postgres_client_account_index::TokenSecondaryIndexEntry,
     },
     chrono::Utc,
     crossbeam_channel::{bounded, Receiver, RecvTimeoutError, Sender},
@@ -67,8 +67,8 @@ pub struct SimplePostgresClient {
     pending_account_updates: Vec<DbAccountInfo>,
     index_token_owner: bool,
     index_token_mint: bool,
-    pending_token_owner_index: Vec<TokenSecondaryIndex>,
-    pending_token_mint_index: Vec<TokenSecondaryIndex>,
+    pending_token_owner_index: Vec<TokenSecondaryIndexEntry>,
+    pending_token_mint_index: Vec<TokenSecondaryIndexEntry>,
     client: Mutex<PostgresSqlClientWrapper>,
 }
 

--- a/src/postgres_client.rs
+++ b/src/postgres_client.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::integer_arithmetic)]
 
+mod postgres_client_account_index;
 mod postgres_client_block_metadata;
 mod postgres_client_transaction;
 
@@ -9,8 +10,7 @@ use {
         accountsdb_plugin_postgres::{
             AccountsDbPluginPostgresConfig, AccountsDbPluginPostgresError,
         },
-        inline_spl_token::{self, GenericTokenAccount},
-        inline_spl_token_2022,
+        postgres_client::postgres_client_account_index::TokenSecondaryIndex,
     },
     chrono::Utc,
     crossbeam_channel::{bounded, Receiver, RecvTimeoutError, Sender},
@@ -25,7 +25,7 @@ use {
     },
     solana_measure::measure::Measure,
     solana_metrics::*,
-    solana_sdk::{pubkey::Pubkey, timing::AtomicInterval},
+    solana_sdk::timing::AtomicInterval,
     std::{
         sync::{
             atomic::{AtomicBool, AtomicUsize, Ordering},
@@ -44,7 +44,6 @@ const DEFAULT_POSTGRES_PORT: u16 = 5432;
 const DEFAULT_THREADS_COUNT: usize = 100;
 const DEFAULT_ACCOUNTS_INSERT_BATCH_SIZE: usize = 10;
 const ACCOUNT_COLUMN_COUNT: usize = 9;
-const TOKEN_IDX_COLUMN_COUNT: usize = 2;
 const DEFAULT_PANIC_ON_DB_ERROR: bool = false;
 const DEFAULT_STORE_ACCOUNT_HISTORICAL_DATA: bool = false;
 
@@ -61,12 +60,6 @@ struct PostgresSqlClientWrapper {
     insert_token_mint_idx_stmt: Option<Statement>,
     bulk_insert_token_owner_idx_stmt: Option<Statement>,
     bulk_insert_token_mint_idx_stmt: Option<Statement>,
-}
-
-/// Model the secondary index for token owner and mint
-pub struct TokenSecondaryIndex {
-    owner: Vec<u8>,
-    inner_key: Vec<u8>,
 }
 
 pub struct SimplePostgresClient {
@@ -328,86 +321,6 @@ impl SimplePostgresClient {
                 )))
             }
             Ok(client) => Ok(client),
-        }
-    }
-
-    fn build_bulk_token_owner_index_insert_statement(
-        client: &mut Client,
-        config: &AccountsDbPluginPostgresConfig,
-    ) -> Result<Statement, AccountsDbPluginError> {
-        let batch_size = config
-            .batch_size
-            .unwrap_or(DEFAULT_ACCOUNTS_INSERT_BATCH_SIZE);
-        let mut stmt =
-            String::from("INSERT INTO spl_token_owner_index AS idx (owner_key, inner_key) VALUES");
-        for j in 0..batch_size {
-            let row = j * TOKEN_IDX_COLUMN_COUNT;
-            let val_str = format!("(${}, ${})", row + 1, row + 2,);
-
-            if j == 0 {
-                stmt = format!("{} {}", &stmt, val_str);
-            } else {
-                stmt = format!("{}, {}", &stmt, val_str);
-            }
-        }
-
-        let handle_conflict = "ON CONFLICT DO NOTHING";
-
-        stmt = format!("{} {}", stmt, handle_conflict);
-
-        info!("{}", stmt);
-        let bulk_stmt = client.prepare(&stmt);
-
-        match bulk_stmt {
-            Err(err) => {
-                return Err(AccountsDbPluginError::Custom(Box::new(AccountsDbPluginPostgresError::DataSchemaError {
-                    msg: format!(
-                        "Error in preparing for the token owner index update PostgreSQL database: {} host: {:?} user: {:?} config: {:?}",
-                        err, config.host, config.user, config
-                    ),
-                })));
-            }
-            Ok(update_account_stmt) => Ok(update_account_stmt),
-        }
-    }
-
-    fn build_bulk_token_mint_index_insert_statement(
-        client: &mut Client,
-        config: &AccountsDbPluginPostgresConfig,
-    ) -> Result<Statement, AccountsDbPluginError> {
-        let batch_size = config
-            .batch_size
-            .unwrap_or(DEFAULT_ACCOUNTS_INSERT_BATCH_SIZE);
-        let mut stmt =
-            String::from("INSERT INTO spl_token_mint_index AS idx (mint_key, inner_key) VALUES");
-        for j in 0..batch_size {
-            let row = j * TOKEN_IDX_COLUMN_COUNT;
-            let val_str = format!("(${}, ${})", row + 1, row + 2,);
-
-            if j == 0 {
-                stmt = format!("{} {}", &stmt, val_str);
-            } else {
-                stmt = format!("{}, {}", &stmt, val_str);
-            }
-        }
-
-        let handle_conflict = "ON CONFLICT DO NOTHING";
-
-        stmt = format!("{} {}", stmt, handle_conflict);
-
-        info!("{}", stmt);
-        let bulk_stmt = client.prepare(&stmt);
-
-        match bulk_stmt {
-            Err(err) => {
-                return Err(AccountsDbPluginError::Custom(Box::new(AccountsDbPluginPostgresError::DataSchemaError {
-                    msg: format!(
-                        "Error in preparing for the token mint index update PostgreSQL database: {} host: {:?} user: {:?} config: {:?}",
-                        err, config.host, config.user, config
-                    ),
-                })));
-            }
-            Ok(update_account_stmt) => Ok(update_account_stmt),
         }
     }
 
@@ -673,96 +586,6 @@ impl SimplePostgresClient {
         Ok(())
     }
 
-    fn update_token_owner_idx_gen<G: GenericTokenAccount>(
-        client: &mut Client,
-        statement: &Statement,
-        token_id: &Pubkey,
-        account: &DbAccountInfo,
-    ) -> Result<(), AccountsDbPluginError> {
-        if account.owner() == token_id.to_bytes() {
-            if let Some(owner_key) = G::unpack_account_owner(account.data()) {
-                let owner_key = owner_key.to_bytes().to_vec();
-                let pubkey = account.pubkey();
-                let result = client.execute(statement, &[&owner_key, &pubkey]);
-                if let Err(err) = result {
-                    let msg = format!(
-                        "Failed to update the token owner index to the PostgreSQL database. Error: {:?}",
-                        err
-                    );
-                    error!("{}", msg);
-                    return Err(AccountsDbPluginError::AccountsUpdateError { msg });
-                }
-            }
-        }
-
-        Ok(())
-    }
-
-    fn update_token_mint_idx_gen<G: GenericTokenAccount>(
-        client: &mut Client,
-        statement: &Statement,
-        token_id: &Pubkey,
-        account: &DbAccountInfo,
-    ) -> Result<(), AccountsDbPluginError> {
-        if account.owner() == token_id.to_bytes() {
-            if let Some(mint_key) = G::unpack_account_mint(account.data()) {
-                let mint_key = mint_key.to_bytes().to_vec();
-                let pubkey = account.pubkey();
-                let result = client.execute(statement, &[&mint_key, &pubkey]);
-                if let Err(err) = result {
-                    let msg = format!(
-                        "Failed to update the token mint index to the PostgreSQL database. Error: {:?}",
-                        err
-                    );
-                    error!("{}", msg);
-                    return Err(AccountsDbPluginError::AccountsUpdateError { msg });
-                }
-            }
-        }
-
-        Ok(())
-    }
-
-    fn update_token_owner_idx(
-        client: &mut Client,
-        statement: &Statement,
-        account: &DbAccountInfo,
-    ) -> Result<(), AccountsDbPluginError> {
-        Self::update_token_owner_idx_gen::<inline_spl_token::Account>(
-            client,
-            statement,
-            &inline_spl_token::id(),
-            account,
-        )?;
-
-        Self::update_token_owner_idx_gen::<inline_spl_token_2022::Account>(
-            client,
-            statement,
-            &inline_spl_token_2022::id(),
-            account,
-        )
-    }
-
-    fn update_token_mint_idx(
-        client: &mut Client,
-        statement: &Statement,
-        account: &DbAccountInfo,
-    ) -> Result<(), AccountsDbPluginError> {
-        Self::update_token_mint_idx_gen::<inline_spl_token::Account>(
-            client,
-            statement,
-            &inline_spl_token::id(),
-            account,
-        )?;
-
-        Self::update_token_mint_idx_gen::<inline_spl_token_2022::Account>(
-            client,
-            statement,
-            &inline_spl_token_2022::id(),
-            account,
-        )
-    }
-
     /// Update or insert a single account
     fn upsert_account(&mut self, account: &DbAccountInfo) -> Result<(), AccountsDbPluginError> {
         let client = self.client.get_mut().unwrap();
@@ -782,65 +605,6 @@ impl SimplePostgresClient {
         }
 
         Ok(())
-    }
-
-    fn queue_token_owner_idx_gen<G: GenericTokenAccount>(
-        &mut self,
-        token_id: &Pubkey,
-        account: &DbAccountInfo,
-    ) {
-        if account.owner() == token_id.to_bytes() {
-            if let Some(owner_key) = G::unpack_account_owner(account.data()) {
-                let owner_key = owner_key.to_bytes().to_vec();
-                let pubkey = account.pubkey();
-                self.pending_token_owner_idx.push(TokenSecondaryIndex {
-                    owner: owner_key,
-                    inner_key: pubkey.to_vec(),
-                });
-            }
-        }
-    }
-
-    fn queue_token_mint_idx_gen<G: GenericTokenAccount>(
-        &mut self,
-        token_id: &Pubkey,
-        account: &DbAccountInfo,
-    ) {
-        if account.owner() == token_id.to_bytes() {
-            if let Some(mint_key) = G::unpack_account_mint(account.data()) {
-                let mint_key = mint_key.to_bytes().to_vec();
-                let pubkey = account.pubkey();
-                self.pending_token_mint_idx.push(TokenSecondaryIndex {
-                    owner: mint_key,
-                    inner_key: pubkey.to_vec(),
-                })
-            }
-        }
-    }
-
-    /// Queue bulk insert secondary indexes
-    fn queue_secondary_indexes(&mut self, account: &DbAccountInfo) {
-        if self.index_token_owner {
-            self.queue_token_owner_idx_gen::<inline_spl_token::Account>(
-                &inline_spl_token::id(),
-                account,
-            );
-            self.queue_token_owner_idx_gen::<inline_spl_token_2022::Account>(
-                &inline_spl_token_2022::id(),
-                account,
-            );
-        }
-
-        if self.index_token_mint {
-            self.queue_token_mint_idx_gen::<inline_spl_token::Account>(
-                &inline_spl_token::id(),
-                account,
-            );
-            self.queue_token_mint_idx_gen::<inline_spl_token_2022::Account>(
-                &inline_spl_token_2022::id(),
-                account,
-            );
-        }
     }
 
     /// Insert accounts in batch to reduce network overhead
@@ -910,114 +674,6 @@ impl SimplePostgresClient {
             );
             inc_new_counter_debug!(
                 "accountsdb-plugin-postgres-update-account-count",
-                self.batch_size,
-                10000,
-                10000
-            );
-        }
-        Ok(())
-    }
-
-    fn bulk_insert_token_owner_idx(&mut self) -> Result<(), AccountsDbPluginError> {
-        if self.pending_token_owner_idx.len() == self.batch_size {
-            let mut measure = Measure::start("accountsdb-plugin-postgres-prepare-owner-idx-values");
-
-            let mut values: Vec<&(dyn types::ToSql + Sync)> =
-                Vec::with_capacity(self.batch_size * TOKEN_IDX_COLUMN_COUNT);
-            for j in 0..self.batch_size {
-                let index = &self.pending_token_owner_idx[j];
-                values.push(&index.owner);
-                values.push(&index.inner_key);
-            }
-            measure.stop();
-            inc_new_counter_debug!(
-                "accountsdb-plugin-postgres-prepare-owner-idx-values-us",
-                measure.as_us() as usize,
-                10000,
-                10000
-            );
-
-            let mut measure = Measure::start("accountsdb-plugin-postgres-update-owner-idx-account");
-            let client = self.client.get_mut().unwrap();
-            let result = client.client.query(
-                client.bulk_insert_token_owner_idx_stmt.as_ref().unwrap(),
-                &values,
-            );
-
-            self.pending_token_owner_idx.clear();
-
-            if let Err(err) = result {
-                let msg = format!(
-                    "Failed to persist the update of account to the PostgreSQL database. Error: {:?}",
-                    err
-                );
-                error!("{}", msg);
-                return Err(AccountsDbPluginError::AccountsUpdateError { msg });
-            }
-
-            measure.stop();
-            inc_new_counter_debug!(
-                "accountsdb-plugin-postgres-update-owner-idx-us",
-                measure.as_us() as usize,
-                10000,
-                10000
-            );
-            inc_new_counter_debug!(
-                "accountsdb-plugin-postgres-update-owner-idx-count",
-                self.batch_size,
-                10000,
-                10000
-            );
-        }
-        Ok(())
-    }
-
-    fn bulk_insert_token_mint_idx(&mut self) -> Result<(), AccountsDbPluginError> {
-        if self.pending_token_owner_idx.len() == self.batch_size {
-            let mut measure = Measure::start("accountsdb-plugin-postgres-prepare-mint-idx-values");
-
-            let mut values: Vec<&(dyn types::ToSql + Sync)> =
-                Vec::with_capacity(self.batch_size * TOKEN_IDX_COLUMN_COUNT);
-            for j in 0..self.batch_size {
-                let index = &self.pending_token_mint_idx[j];
-                values.push(&index.owner);
-                values.push(&index.inner_key);
-            }
-            measure.stop();
-            inc_new_counter_debug!(
-                "accountsdb-plugin-postgres-prepare-mint-idx-values-us",
-                measure.as_us() as usize,
-                10000,
-                10000
-            );
-
-            let mut measure = Measure::start("accountsdb-plugin-postgres-update-mint-idx-account");
-            let client = self.client.get_mut().unwrap();
-            let result = client.client.query(
-                client.bulk_insert_token_mint_idx_stmt.as_ref().unwrap(),
-                &values,
-            );
-
-            self.pending_token_mint_idx.clear();
-
-            if let Err(err) = result {
-                let msg = format!(
-                    "Failed to persist the update of account to the PostgreSQL database. Error: {:?}",
-                    err
-                );
-                error!("{}", msg);
-                return Err(AccountsDbPluginError::AccountsUpdateError { msg });
-            }
-
-            measure.stop();
-            inc_new_counter_debug!(
-                "accountsdb-plugin-postgres-update-mint-idx-us",
-                measure.as_us() as usize,
-                10000,
-                10000
-            );
-            inc_new_counter_debug!(
-                "accountsdb-plugin-postgres-update-mint-idx-count",
                 self.batch_size,
                 10000,
                 10000

--- a/src/postgres_client.rs
+++ b/src/postgres_client.rs
@@ -341,7 +341,7 @@ impl SimplePostgresClient {
         let mut stmt =
             String::from("INSERT INTO spl_token_owner_index AS idx (owner_key, inner_key) VALUES");
         for j in 0..batch_size {
-            let row = j * ACCOUNT_COLUMN_COUNT;
+            let row = j * TOKEN_IDX_COLUMN_COUNT;
             let val_str = format!("(${}, ${})", row + 1, row + 2,);
 
             if j == 0 {
@@ -381,7 +381,7 @@ impl SimplePostgresClient {
         let mut stmt =
             String::from("INSERT INTO spl_token_mint_index AS idx (mint_key, inner_key) VALUES");
         for j in 0..batch_size {
-            let row = j * ACCOUNT_COLUMN_COUNT;
+            let row = j * TOKEN_IDX_COLUMN_COUNT;
             let val_str = format!("(${}, ${})", row + 1, row + 2,);
 
             if j == 0 {
@@ -818,7 +818,7 @@ impl SimplePostgresClient {
         }
     }
 
-    /// Bulk insert secondary indexes
+    /// Queue bulk insert secondary indexes
     fn queue_secondary_indexes(&mut self, account: &DbAccountInfo) {
         if self.index_token_owner {
             self.queue_token_owner_idx_gen::<inline_spl_token::Account>(
@@ -979,7 +979,7 @@ impl SimplePostgresClient {
             let mut values: Vec<&(dyn types::ToSql + Sync)> =
                 Vec::with_capacity(self.batch_size * TOKEN_IDX_COLUMN_COUNT);
             for j in 0..self.batch_size {
-                let index = &self.pending_token_owner_idx[j];
+                let index = &self.pending_token_mint_idx[j];
                 values.push(&index.owner);
                 values.push(&index.inner_key);
             }
@@ -998,7 +998,7 @@ impl SimplePostgresClient {
                 &values,
             );
 
-            self.pending_token_owner_idx.clear();
+            self.pending_token_mint_idx.clear();
 
             if let Err(err) = result {
                 let msg = format!(

--- a/src/postgres_client.rs
+++ b/src/postgres_client.rs
@@ -44,6 +44,7 @@ const DEFAULT_POSTGRES_PORT: u16 = 5432;
 const DEFAULT_THREADS_COUNT: usize = 100;
 const DEFAULT_ACCOUNTS_INSERT_BATCH_SIZE: usize = 10;
 const ACCOUNT_COLUMN_COUNT: usize = 9;
+const TOKEN_IDX_COLUMN_COUNT: usize = 2;
 const DEFAULT_PANIC_ON_DB_ERROR: bool = false;
 const DEFAULT_STORE_ACCOUNT_HISTORICAL_DATA: bool = false;
 
@@ -58,11 +59,23 @@ struct PostgresSqlClientWrapper {
     insert_account_audit_stmt: Option<Statement>,
     insert_token_owner_idx_stmt: Option<Statement>,
     insert_token_mint_idx_stmt: Option<Statement>,
+    bulk_insert_token_owner_idx_stmt: Option<Statement>,
+    bulk_insert_token_mint_idx_stmt: Option<Statement>,
+}
+
+/// Model the secondary index for token owner and mint
+pub struct TokenSecondaryIndex {
+    owner: Vec<u8>,
+    inner_key: Vec<u8>,
 }
 
 pub struct SimplePostgresClient {
     batch_size: usize,
     pending_account_updates: Vec<DbAccountInfo>,
+    index_token_owner: bool,
+    index_token_mint: bool,
+    pending_token_owner_idx: Vec<TokenSecondaryIndex>,
+    pending_token_mint_idx: Vec<TokenSecondaryIndex>,
     client: Mutex<PostgresSqlClientWrapper>,
 }
 
@@ -315,6 +328,86 @@ impl SimplePostgresClient {
                 )))
             }
             Ok(client) => Ok(client),
+        }
+    }
+
+    fn build_bulk_token_owner_index_insert_statement(
+        client: &mut Client,
+        config: &AccountsDbPluginPostgresConfig,
+    ) -> Result<Statement, AccountsDbPluginError> {
+        let batch_size = config
+            .batch_size
+            .unwrap_or(DEFAULT_ACCOUNTS_INSERT_BATCH_SIZE);
+        let mut stmt =
+            String::from("INSERT INTO spl_token_owner_index AS idx (owner_key, inner_key) VALUES");
+        for j in 0..batch_size {
+            let row = j * ACCOUNT_COLUMN_COUNT;
+            let val_str = format!("(${}, ${})", row + 1, row + 2,);
+
+            if j == 0 {
+                stmt = format!("{} {}", &stmt, val_str);
+            } else {
+                stmt = format!("{}, {}", &stmt, val_str);
+            }
+        }
+
+        let handle_conflict = "ON CONFLICT DO NOTHING";
+
+        stmt = format!("{} {}", stmt, handle_conflict);
+
+        info!("{}", stmt);
+        let bulk_stmt = client.prepare(&stmt);
+
+        match bulk_stmt {
+            Err(err) => {
+                return Err(AccountsDbPluginError::Custom(Box::new(AccountsDbPluginPostgresError::DataSchemaError {
+                    msg: format!(
+                        "Error in preparing for the token owner index update PostgreSQL database: {} host: {:?} user: {:?} config: {:?}",
+                        err, config.host, config.user, config
+                    ),
+                })));
+            }
+            Ok(update_account_stmt) => Ok(update_account_stmt),
+        }
+    }
+
+    fn build_bulk_token_mint_index_insert_statement(
+        client: &mut Client,
+        config: &AccountsDbPluginPostgresConfig,
+    ) -> Result<Statement, AccountsDbPluginError> {
+        let batch_size = config
+            .batch_size
+            .unwrap_or(DEFAULT_ACCOUNTS_INSERT_BATCH_SIZE);
+        let mut stmt =
+            String::from("INSERT INTO spl_token_mint_index AS idx (mint_key, inner_key) VALUES");
+        for j in 0..batch_size {
+            let row = j * ACCOUNT_COLUMN_COUNT;
+            let val_str = format!("(${}, ${})", row + 1, row + 2,);
+
+            if j == 0 {
+                stmt = format!("{} {}", &stmt, val_str);
+            } else {
+                stmt = format!("{}, {}", &stmt, val_str);
+            }
+        }
+
+        let handle_conflict = "ON CONFLICT DO NOTHING";
+
+        stmt = format!("{} {}", stmt, handle_conflict);
+
+        info!("{}", stmt);
+        let bulk_stmt = client.prepare(&stmt);
+
+        match bulk_stmt {
+            Err(err) => {
+                return Err(AccountsDbPluginError::Custom(Box::new(AccountsDbPluginPostgresError::DataSchemaError {
+                    msg: format!(
+                        "Error in preparing for the token mint index update PostgreSQL database: {} host: {:?} user: {:?} config: {:?}",
+                        err, config.host, config.user, config
+                    ),
+                })));
+            }
+            Ok(update_account_stmt) => Ok(update_account_stmt),
         }
     }
 
@@ -691,13 +784,79 @@ impl SimplePostgresClient {
         Ok(())
     }
 
+    fn queue_token_owner_idx_gen<G: GenericTokenAccount>(
+        &mut self,
+        token_id: &Pubkey,
+        account: &DbAccountInfo,
+    ) {
+        if account.owner() == token_id.to_bytes() {
+            if let Some(owner_key) = G::unpack_account_owner(account.data()) {
+                let owner_key = owner_key.to_bytes().to_vec();
+                let pubkey = account.pubkey();
+                self.pending_token_owner_idx.push(TokenSecondaryIndex {
+                    owner: owner_key,
+                    inner_key: pubkey.to_vec(),
+                });
+            }
+        }
+    }
+
+    fn queue_token_mint_idx_gen<G: GenericTokenAccount>(
+        &mut self,
+        token_id: &Pubkey,
+        account: &DbAccountInfo,
+    ) {
+        if account.owner() == token_id.to_bytes() {
+            if let Some(mint_key) = G::unpack_account_mint(account.data()) {
+                let mint_key = mint_key.to_bytes().to_vec();
+                let pubkey = account.pubkey();
+                self.pending_token_mint_idx.push(TokenSecondaryIndex {
+                    owner: mint_key,
+                    inner_key: pubkey.to_vec(),
+                })
+            }
+        }
+    }
+
+    /// Bulk insert secondary indexes
+    fn queue_secondary_indexes(&mut self, account: &DbAccountInfo) {
+        if self.index_token_owner {
+            self.queue_token_owner_idx_gen::<inline_spl_token::Account>(
+                &inline_spl_token::id(),
+                account,
+            );
+            self.queue_token_owner_idx_gen::<inline_spl_token_2022::Account>(
+                &inline_spl_token_2022::id(),
+                account,
+            );
+        }
+
+        if self.index_token_mint {
+            self.queue_token_mint_idx_gen::<inline_spl_token::Account>(
+                &inline_spl_token::id(),
+                account,
+            );
+            self.queue_token_mint_idx_gen::<inline_spl_token_2022::Account>(
+                &inline_spl_token_2022::id(),
+                account,
+            );
+        }
+    }
+
     /// Insert accounts in batch to reduce network overhead
     fn insert_accounts_in_batch(
         &mut self,
         account: DbAccountInfo,
     ) -> Result<(), AccountsDbPluginError> {
+        self.queue_secondary_indexes(&account);
         self.pending_account_updates.push(account);
 
+        self.bulk_insert_accounts()?;
+        self.bulk_insert_token_owner_idx()?;
+        self.bulk_insert_token_mint_idx()
+    }
+
+    fn bulk_insert_accounts(&mut self) -> Result<(), AccountsDbPluginError> {
         if self.pending_account_updates.len() == self.batch_size {
             let mut measure = Measure::start("accountsdb-plugin-postgres-prepare-values");
 
@@ -732,6 +891,7 @@ impl SimplePostgresClient {
                 .query(&client.bulk_account_insert_stmt, &values);
 
             self.pending_account_updates.clear();
+
             if let Err(err) = result {
                 let msg = format!(
                     "Failed to persist the update of account to the PostgreSQL database. Error: {:?}",
@@ -740,6 +900,7 @@ impl SimplePostgresClient {
                 error!("{}", msg);
                 return Err(AccountsDbPluginError::AccountsUpdateError { msg });
             }
+
             measure.stop();
             inc_new_counter_debug!(
                 "accountsdb-plugin-postgres-update-account-us",
@@ -749,6 +910,114 @@ impl SimplePostgresClient {
             );
             inc_new_counter_debug!(
                 "accountsdb-plugin-postgres-update-account-count",
+                self.batch_size,
+                10000,
+                10000
+            );
+        }
+        Ok(())
+    }
+
+    fn bulk_insert_token_owner_idx(&mut self) -> Result<(), AccountsDbPluginError> {
+        if self.pending_token_owner_idx.len() == self.batch_size {
+            let mut measure = Measure::start("accountsdb-plugin-postgres-prepare-owner-idx-values");
+
+            let mut values: Vec<&(dyn types::ToSql + Sync)> =
+                Vec::with_capacity(self.batch_size * TOKEN_IDX_COLUMN_COUNT);
+            for j in 0..self.batch_size {
+                let index = &self.pending_token_owner_idx[j];
+                values.push(&index.owner);
+                values.push(&index.inner_key);
+            }
+            measure.stop();
+            inc_new_counter_debug!(
+                "accountsdb-plugin-postgres-prepare-owner-idx-values-us",
+                measure.as_us() as usize,
+                10000,
+                10000
+            );
+
+            let mut measure = Measure::start("accountsdb-plugin-postgres-update-owner-idx-account");
+            let client = self.client.get_mut().unwrap();
+            let result = client.client.query(
+                client.bulk_insert_token_owner_idx_stmt.as_ref().unwrap(),
+                &values,
+            );
+
+            self.pending_token_owner_idx.clear();
+
+            if let Err(err) = result {
+                let msg = format!(
+                    "Failed to persist the update of account to the PostgreSQL database. Error: {:?}",
+                    err
+                );
+                error!("{}", msg);
+                return Err(AccountsDbPluginError::AccountsUpdateError { msg });
+            }
+
+            measure.stop();
+            inc_new_counter_debug!(
+                "accountsdb-plugin-postgres-update-owner-idx-us",
+                measure.as_us() as usize,
+                10000,
+                10000
+            );
+            inc_new_counter_debug!(
+                "accountsdb-plugin-postgres-update-owner-idx-count",
+                self.batch_size,
+                10000,
+                10000
+            );
+        }
+        Ok(())
+    }
+
+    fn bulk_insert_token_mint_idx(&mut self) -> Result<(), AccountsDbPluginError> {
+        if self.pending_token_owner_idx.len() == self.batch_size {
+            let mut measure = Measure::start("accountsdb-plugin-postgres-prepare-mint-idx-values");
+
+            let mut values: Vec<&(dyn types::ToSql + Sync)> =
+                Vec::with_capacity(self.batch_size * TOKEN_IDX_COLUMN_COUNT);
+            for j in 0..self.batch_size {
+                let index = &self.pending_token_owner_idx[j];
+                values.push(&index.owner);
+                values.push(&index.inner_key);
+            }
+            measure.stop();
+            inc_new_counter_debug!(
+                "accountsdb-plugin-postgres-prepare-mint-idx-values-us",
+                measure.as_us() as usize,
+                10000,
+                10000
+            );
+
+            let mut measure = Measure::start("accountsdb-plugin-postgres-update-mint-idx-account");
+            let client = self.client.get_mut().unwrap();
+            let result = client.client.query(
+                client.bulk_insert_token_mint_idx_stmt.as_ref().unwrap(),
+                &values,
+            );
+
+            self.pending_token_owner_idx.clear();
+
+            if let Err(err) = result {
+                let msg = format!(
+                    "Failed to persist the update of account to the PostgreSQL database. Error: {:?}",
+                    err
+                );
+                error!("{}", msg);
+                return Err(AccountsDbPluginError::AccountsUpdateError { msg });
+            }
+
+            measure.stop();
+            inc_new_counter_debug!(
+                "accountsdb-plugin-postgres-update-mint-idx-us",
+                measure.as_us() as usize,
+                10000,
+                10000
+            );
+            inc_new_counter_debug!(
+                "accountsdb-plugin-postgres-update-mint-idx-count",
                 self.batch_size,
                 10000,
                 10000
@@ -806,6 +1075,20 @@ impl SimplePostgresClient {
             None
         };
 
+        let bulk_insert_token_owner_idx_stmt = if let Some(true) = config.index_token_owner {
+            let stmt = Self::build_bulk_token_owner_index_insert_statement(&mut client, config)?;
+            Some(stmt)
+        } else {
+            None
+        };
+
+        let bulk_insert_token_mint_idx_stmt = if let Some(true) = config.index_token_mint {
+            let stmt = Self::build_bulk_token_mint_index_insert_statement(&mut client, config)?;
+            Some(stmt)
+        } else {
+            None
+        };
+
         let insert_token_owner_idx_stmt = if let Some(true) = config.index_token_owner {
             Some(Self::build_single_token_owner_index_upsert_statement(
                 &mut client,
@@ -839,7 +1122,13 @@ impl SimplePostgresClient {
                 insert_account_audit_stmt,
                 insert_token_owner_idx_stmt,
                 insert_token_mint_idx_stmt,
+                bulk_insert_token_owner_idx_stmt,
+                bulk_insert_token_mint_idx_stmt,
             }),
+            index_token_owner: config.index_token_owner.unwrap_or_default(),
+            index_token_mint: config.index_token_mint.unwrap_or(false),
+            pending_token_owner_idx: Vec::with_capacity(batch_size),
+            pending_token_mint_idx: Vec::with_capacity(batch_size),
         })
     }
 }

--- a/src/postgres_client.rs
+++ b/src/postgres_client.rs
@@ -421,26 +421,6 @@ impl SimplePostgresClient {
         }
     }
 
-    fn build_single_token_owner_index_upsert_statement(
-        client: &mut Client,
-        config: &AccountsDbPluginPostgresConfig,
-    ) -> Result<Statement, AccountsDbPluginError> {
-        let stmt = "INSERT INTO spl_token_owner_index AS owner_index (owner_key, inner_key) \
-        VALUES ($1, $2) ON CONFLICT DO NOTHING";
-
-        Self::prepare_query_statement(client, config, stmt)
-    }
-
-    fn build_single_token_mint_index_upsert_statement(
-        client: &mut Client,
-        config: &AccountsDbPluginPostgresConfig,
-    ) -> Result<Statement, AccountsDbPluginError> {
-        let stmt = "INSERT INTO spl_token_mint_index AS mint_index (mint_key, inner_key) \
-        VALUES ($1, $2) ON CONFLICT DO NOTHING";
-
-        Self::prepare_query_statement(client, config, stmt)
-    }
-
     fn build_account_audit_insert_statement(
         client: &mut Client,
         config: &AccountsDbPluginPostgresConfig,

--- a/src/postgres_client/postgres_client_account_index.rs
+++ b/src/postgres_client/postgres_client_account_index.rs
@@ -43,7 +43,7 @@ impl SimplePostgresClient {
         config: &AccountsDbPluginPostgresConfig,
     ) -> Result<Statement, AccountsDbPluginError> {
         let stmt = "INSERT INTO spl_token_mint_index AS mint_index (mint_key, inner_key, slot) \
-        VALUES ($1, $2, $3) ON CONFLICT (owner_key, inner_key) DO UPDATE SET slot=excluded.slot where mint_index.slot < excluded.slot";
+        VALUES ($1, $2, $3) ON CONFLICT (mint_key, inner_key) DO UPDATE SET slot=excluded.slot where mint_index.slot < excluded.slot";
 
         Self::prepare_query_statement(client, config, stmt)
     }
@@ -114,7 +114,7 @@ impl SimplePostgresClient {
         }
 
         let handle_conflict =
-            "ON CONFLICT (owner_key, inner_key) DO UPDATE SET slot=excluded.slot where index.slot < excluded.slot";
+            "ON CONFLICT (mint_key, inner_key) DO UPDATE SET slot=excluded.slot where index.slot < excluded.slot";
 
         stmt = format!("{} {}", stmt, handle_conflict);
 

--- a/src/postgres_client/postgres_client_account_index.rs
+++ b/src/postgres_client/postgres_client_account_index.rs
@@ -337,6 +337,7 @@ impl SimplePostgresClient {
         Ok(())
     }
 
+    /// Function for updating a single token owner index.
     pub fn update_token_owner_index(
         client: &mut Client,
         statement: &Statement,
@@ -357,6 +358,7 @@ impl SimplePostgresClient {
         )
     }
 
+    /// Function for updating a single token mint index.
     pub fn update_token_mint_index(
         client: &mut Client,
         statement: &Statement,
@@ -375,5 +377,13 @@ impl SimplePostgresClient {
             &inline_spl_token_2022::id(),
             account,
         )
+    }
+
+    /// Clean up the buffered indexes -- we do not need to
+    /// write them to disk individually as they have already been handled
+    /// when the accounts were flushed out individually in `upsert_account_internal`.
+    pub fn clear_buffered_indexes(&mut self) {
+        self.pending_token_owner_index.clear();
+        self.pending_token_mint_index.clear();
     }
 }

--- a/src/postgres_client/postgres_client_account_index.rs
+++ b/src/postgres_client/postgres_client_account_index.rs
@@ -23,7 +23,7 @@ const TOKEN_INDEX_COLUMN_COUNT: usize = 3;
 /// Model the secondary index for token owner and mint
 pub struct TokenSecondaryIndex {
     owner: Vec<u8>,
-    inner_key: Vec<u8>,
+    account_key: Vec<u8>,
     slot: i64,
 }
 
@@ -32,8 +32,12 @@ impl SimplePostgresClient {
         client: &mut Client,
         config: &AccountsDbPluginPostgresConfig,
     ) -> Result<Statement, AccountsDbPluginError> {
-        let stmt = "INSERT INTO spl_token_owner_index AS owner_index (owner_key, inner_key, slot) \
-        VALUES ($1, $2, $3) ON CONFLICT (owner_key, inner_key) DO UPDATE SET slot=excluded.slot where owner_index.slot < excluded.slot";
+        let stmt =
+            "INSERT INTO spl_token_owner_index AS owner_index (owner_key, account_key, slot) \
+        VALUES ($1, $2, $3) \
+        ON CONFLICT (owner_key, account_key) \
+        DO UPDATE SET slot=excluded.slot \
+        WHERE owner_index.slot < excluded.slot";
 
         Self::prepare_query_statement(client, config, stmt)
     }
@@ -42,10 +46,60 @@ impl SimplePostgresClient {
         client: &mut Client,
         config: &AccountsDbPluginPostgresConfig,
     ) -> Result<Statement, AccountsDbPluginError> {
-        let stmt = "INSERT INTO spl_token_mint_index AS mint_index (mint_key, inner_key, slot) \
-        VALUES ($1, $2, $3) ON CONFLICT (mint_key, inner_key) DO UPDATE SET slot=excluded.slot where mint_index.slot < excluded.slot";
+        let stmt = "INSERT INTO spl_token_mint_index AS mint_index (mint_key, account_key, slot) \
+        VALUES ($1, $2, $3) \
+        ON CONFLICT (mint_key, account_key) \
+        DO UPDATE SET slot=excluded.slot \
+        WHERE mint_index.slot < excluded.slot";
 
         Self::prepare_query_statement(client, config, stmt)
+    }
+
+    /// Common build the token mint index bulk insert statement.
+    pub fn build_bulk_token_index_insert_statement_common(
+        client: &mut Client,
+        table: &str,
+        source_key_name: &str,
+        config: &AccountsDbPluginPostgresConfig,
+    ) -> Result<Statement, AccountsDbPluginError> {
+        let batch_size = config
+            .batch_size
+            .unwrap_or(DEFAULT_ACCOUNTS_INSERT_BATCH_SIZE);
+        let mut stmt = format!(
+            "INSERT INTO {} AS index ({}, account_key, slot) VALUES",
+            table, source_key_name
+        );
+        for j in 0..batch_size {
+            let row = j * TOKEN_INDEX_COLUMN_COUNT;
+            let val_str = format!("(${}, ${}, ${})", row + 1, row + 2, row + 3);
+
+            if j == 0 {
+                stmt = format!("{} {}", &stmt, val_str);
+            } else {
+                stmt = format!("{}, {}", &stmt, val_str);
+            }
+        }
+
+        let handle_conflict = format!(
+            "ON CONFLICT ({}, account_key) DO UPDATE SET slot=excluded.slot where index.slot < excluded.slot",
+            source_key_name);
+
+        stmt = format!("{} {}", stmt, handle_conflict);
+
+        info!("{}", stmt);
+        let bulk_stmt = client.prepare(&stmt);
+
+        match bulk_stmt {
+            Err(err) => {
+                return Err(AccountsDbPluginError::Custom(Box::new(AccountsDbPluginPostgresError::DataSchemaError {
+                    msg: format!(
+                        "Error in preparing for the {} index update PostgreSQL database: {} host: {:?} user: {:?} config: {:?}",
+                        table, err, config.host, config.user, config
+                    ),
+                })));
+            }
+            Ok(statement) => Ok(statement),
+        }
     }
 
     /// Build the token owner index bulk insert statement
@@ -53,42 +107,12 @@ impl SimplePostgresClient {
         client: &mut Client,
         config: &AccountsDbPluginPostgresConfig,
     ) -> Result<Statement, AccountsDbPluginError> {
-        let batch_size = config
-            .batch_size
-            .unwrap_or(DEFAULT_ACCOUNTS_INSERT_BATCH_SIZE);
-        let mut stmt = String::from(
-            "INSERT INTO spl_token_owner_index AS index (owner_key, inner_key, slot) VALUES",
-        );
-        for j in 0..batch_size {
-            let row = j * TOKEN_INDEX_COLUMN_COUNT;
-            let val_str = format!("(${}, ${}, ${})", row + 1, row + 2, row + 3);
-
-            if j == 0 {
-                stmt = format!("{} {}", &stmt, val_str);
-            } else {
-                stmt = format!("{}, {}", &stmt, val_str);
-            }
-        }
-
-        let handle_conflict =
-            "ON CONFLICT (owner_key, inner_key) DO UPDATE SET slot=excluded.slot where index.slot < excluded.slot";
-
-        stmt = format!("{} {}", stmt, handle_conflict);
-
-        info!("{}", stmt);
-        let bulk_stmt = client.prepare(&stmt);
-
-        match bulk_stmt {
-            Err(err) => {
-                return Err(AccountsDbPluginError::Custom(Box::new(AccountsDbPluginPostgresError::DataSchemaError {
-                    msg: format!(
-                        "Error in preparing for the token owner index update PostgreSQL database: {} host: {:?} user: {:?} config: {:?}",
-                        err, config.host, config.user, config
-                    ),
-                })));
-            }
-            Ok(update_account_stmt) => Ok(update_account_stmt),
-        }
+        Self::build_bulk_token_index_insert_statement_common(
+            client,
+            "spl_token_owner_index",
+            "owner_key",
+            config,
+        )
     }
 
     /// Build the token mint index bulk insert statement.
@@ -96,162 +120,96 @@ impl SimplePostgresClient {
         client: &mut Client,
         config: &AccountsDbPluginPostgresConfig,
     ) -> Result<Statement, AccountsDbPluginError> {
-        let batch_size = config
-            .batch_size
-            .unwrap_or(DEFAULT_ACCOUNTS_INSERT_BATCH_SIZE);
-        let mut stmt = String::from(
-            "INSERT INTO spl_token_mint_index AS index (mint_key, inner_key, slot) VALUES",
-        );
-        for j in 0..batch_size {
-            let row = j * TOKEN_INDEX_COLUMN_COUNT;
-            let val_str = format!("(${}, ${}, ${})", row + 1, row + 2, row + 3);
+        Self::build_bulk_token_index_insert_statement_common(
+            client,
+            "spl_token_mint_index",
+            "mint_key",
+            config,
+        )
+    }
 
-            if j == 0 {
-                stmt = format!("{} {}", &stmt, val_str);
-            } else {
-                stmt = format!("{}, {}", &stmt, val_str);
+    /// Execute the common token bulk insert query.
+    fn bulk_insert_token_index_common(
+        batch_size: usize,
+        client: &mut Client,
+        indexes: &mut Vec<TokenSecondaryIndex>,
+        query: &Statement,
+    ) -> Result<(), AccountsDbPluginError> {
+        if indexes.len() == batch_size {
+            let mut measure = Measure::start("accountsdb-plugin-postgres-prepare-index-values");
+
+            let mut values: Vec<&(dyn types::ToSql + Sync)> =
+                Vec::with_capacity(batch_size * TOKEN_INDEX_COLUMN_COUNT);
+            for index in indexes.iter().take(batch_size) {
+                values.push(&index.owner);
+                values.push(&index.account_key);
+                values.push(&index.slot);
             }
-        }
+            measure.stop();
+            inc_new_counter_debug!(
+                "accountsdb-plugin-postgres-prepare-index-values-us",
+                measure.as_us() as usize,
+                10000,
+                10000
+            );
 
-        let handle_conflict =
-            "ON CONFLICT (mint_key, inner_key) DO UPDATE SET slot=excluded.slot where index.slot < excluded.slot";
+            let mut measure = Measure::start("accountsdb-plugin-postgres-update-index-account");
+            let result = client.query(query, &values);
 
-        stmt = format!("{} {}", stmt, handle_conflict);
+            indexes.clear();
 
-        info!("{}", stmt);
-        let bulk_stmt = client.prepare(&stmt);
-
-        match bulk_stmt {
-            Err(err) => {
-                return Err(AccountsDbPluginError::Custom(Box::new(AccountsDbPluginPostgresError::DataSchemaError {
-                    msg: format!(
-                        "Error in preparing for the token mint index update PostgreSQL database: {} host: {:?} user: {:?} config: {:?}",
-                        err, config.host, config.user, config
-                    ),
-                })));
+            if let Err(err) = result {
+                let msg = format!(
+                    "Failed to persist the update of account to the PostgreSQL database. Error: {:?}",
+                    err
+                );
+                error!("{}", msg);
+                return Err(AccountsDbPluginError::AccountsUpdateError { msg });
             }
-            Ok(update_account_stmt) => Ok(update_account_stmt),
+
+            measure.stop();
+            inc_new_counter_debug!(
+                "accountsdb-plugin-postgres-update-index-us",
+                measure.as_us() as usize,
+                10000,
+                10000
+            );
+            inc_new_counter_debug!(
+                "accountsdb-plugin-postgres-update-index-count",
+                batch_size,
+                10000,
+                10000
+            );
         }
+        Ok(())
     }
 
     /// Execute the token owner bulk insert query.
     pub fn bulk_insert_token_owner_index(&mut self) -> Result<(), AccountsDbPluginError> {
-        if self.pending_token_owner_index.len() == self.batch_size {
-            let mut measure =
-                Measure::start("accountsdb-plugin-postgres-prepare-owner-index-values");
-
-            let mut values: Vec<&(dyn types::ToSql + Sync)> =
-                Vec::with_capacity(self.batch_size * TOKEN_INDEX_COLUMN_COUNT);
-            for j in 0..self.batch_size {
-                let index = &self.pending_token_owner_index[j];
-                values.push(&index.owner);
-                values.push(&index.inner_key);
-                values.push(&index.slot);
-            }
-            measure.stop();
-            inc_new_counter_debug!(
-                "accountsdb-plugin-postgres-prepare-owner-index-values-us",
-                measure.as_us() as usize,
-                10000,
-                10000
-            );
-
-            let mut measure =
-                Measure::start("accountsdb-plugin-postgres-update-owner-index-account");
-            let client = self.client.get_mut().unwrap();
-            let result = client.client.query(
-                client.bulk_insert_token_owner_index_stmt.as_ref().unwrap(),
-                &values,
-            );
-
-            self.pending_token_owner_index.clear();
-
-            if let Err(err) = result {
-                let msg = format!(
-                    "Failed to persist the update of account to the PostgreSQL database. Error: {:?}",
-                    err
-                );
-                error!("{}", msg);
-                return Err(AccountsDbPluginError::AccountsUpdateError { msg });
-            }
-
-            measure.stop();
-            inc_new_counter_debug!(
-                "accountsdb-plugin-postgres-update-owner-index-us",
-                measure.as_us() as usize,
-                10000,
-                10000
-            );
-            inc_new_counter_debug!(
-                "accountsdb-plugin-postgres-update-owner-index-count",
-                self.batch_size,
-                10000,
-                10000
-            );
-        }
-        Ok(())
+        let client = self.client.get_mut().unwrap();
+        let query = client.bulk_insert_token_owner_index_stmt.as_ref().unwrap();
+        Self::bulk_insert_token_index_common(
+            self.batch_size,
+            &mut client.client,
+            &mut self.pending_token_owner_index,
+            query,
+        )
     }
 
     /// Execute the token mint index bulk insert query.
     pub fn bulk_insert_token_mint_index(&mut self) -> Result<(), AccountsDbPluginError> {
-        if self.pending_token_mint_index.len() == self.batch_size {
-            let mut measure =
-                Measure::start("accountsdb-plugin-postgres-prepare-mint-index-values");
-
-            let mut values: Vec<&(dyn types::ToSql + Sync)> =
-                Vec::with_capacity(self.batch_size * TOKEN_INDEX_COLUMN_COUNT);
-            for j in 0..self.batch_size {
-                let index = &self.pending_token_mint_index[j];
-                values.push(&index.owner);
-                values.push(&index.inner_key);
-                values.push(&index.slot);
-            }
-            measure.stop();
-            inc_new_counter_debug!(
-                "accountsdb-plugin-postgres-prepare-mint-index-values-us",
-                measure.as_us() as usize,
-                10000,
-                10000
-            );
-
-            let mut measure =
-                Measure::start("accountsdb-plugin-postgres-update-mint-index-account");
-            let client = self.client.get_mut().unwrap();
-            let result = client.client.query(
-                client.bulk_insert_token_mint_index_stmt.as_ref().unwrap(),
-                &values,
-            );
-
-            self.pending_token_mint_index.clear();
-
-            if let Err(err) = result {
-                let msg = format!(
-                    "Failed to persist the update of account to the PostgreSQL database. Error: {:?}",
-                    err
-                );
-                error!("{}", msg);
-                return Err(AccountsDbPluginError::AccountsUpdateError { msg });
-            }
-
-            measure.stop();
-            inc_new_counter_debug!(
-                "accountsdb-plugin-postgres-update-mint-index-us",
-                measure.as_us() as usize,
-                10000,
-                10000
-            );
-            inc_new_counter_debug!(
-                "accountsdb-plugin-postgres-update-mint-index-count",
-                self.batch_size,
-                10000,
-                10000
-            );
-        }
-        Ok(())
+        let client = self.client.get_mut().unwrap();
+        let query = client.bulk_insert_token_mint_index_stmt.as_ref().unwrap();
+        Self::bulk_insert_token_index_common(
+            self.batch_size,
+            &mut client.client,
+            &mut self.pending_token_mint_index,
+            query,
+        )
     }
 
     /// Generic function to queue the token owner index for bulk insert.
-    fn queue_token_owner_index_gen<G: GenericTokenAccount>(
+    fn queue_token_owner_index_generic<G: GenericTokenAccount>(
         &mut self,
         token_id: &Pubkey,
         account: &DbAccountInfo,
@@ -262,7 +220,7 @@ impl SimplePostgresClient {
                 let pubkey = account.pubkey();
                 self.pending_token_owner_index.push(TokenSecondaryIndex {
                     owner: owner_key,
-                    inner_key: pubkey.to_vec(),
+                    account_key: pubkey.to_vec(),
                     slot: account.slot,
                 });
             }
@@ -270,7 +228,7 @@ impl SimplePostgresClient {
     }
 
     /// Generic function to queue the token mint index for bulk insert.
-    fn queue_token_mint_index_gen<G: GenericTokenAccount>(
+    fn queue_token_mint_index_generic<G: GenericTokenAccount>(
         &mut self,
         token_id: &Pubkey,
         account: &DbAccountInfo,
@@ -281,7 +239,7 @@ impl SimplePostgresClient {
                 let pubkey = account.pubkey();
                 self.pending_token_mint_index.push(TokenSecondaryIndex {
                     owner: mint_key,
-                    inner_key: pubkey.to_vec(),
+                    account_key: pubkey.to_vec(),
                     slot: account.slot,
                 })
             }
@@ -291,22 +249,22 @@ impl SimplePostgresClient {
     /// Queue bulk insert secondary indexes: token owner and token mint indexes.
     pub fn queue_secondary_indexes(&mut self, account: &DbAccountInfo) {
         if self.index_token_owner {
-            self.queue_token_owner_index_gen::<inline_spl_token::Account>(
+            self.queue_token_owner_index_generic::<inline_spl_token::Account>(
                 &inline_spl_token::id(),
                 account,
             );
-            self.queue_token_owner_index_gen::<inline_spl_token_2022::Account>(
+            self.queue_token_owner_index_generic::<inline_spl_token_2022::Account>(
                 &inline_spl_token_2022::id(),
                 account,
             );
         }
 
         if self.index_token_mint {
-            self.queue_token_mint_index_gen::<inline_spl_token::Account>(
+            self.queue_token_mint_index_generic::<inline_spl_token::Account>(
                 &inline_spl_token::id(),
                 account,
             );
-            self.queue_token_mint_index_gen::<inline_spl_token_2022::Account>(
+            self.queue_token_mint_index_generic::<inline_spl_token_2022::Account>(
                 &inline_spl_token_2022::id(),
                 account,
             );
@@ -314,7 +272,7 @@ impl SimplePostgresClient {
     }
 
     /// Generic function to update a single token owner index.
-    fn update_token_owner_index_gen<G: GenericTokenAccount>(
+    fn update_token_owner_index_generic<G: GenericTokenAccount>(
         client: &mut Client,
         statement: &Statement,
         token_id: &Pubkey,
@@ -341,7 +299,7 @@ impl SimplePostgresClient {
     }
 
     /// Generic function to update a single token mint index.
-    fn update_token_mint_index_gen<G: GenericTokenAccount>(
+    fn update_token_mint_index_generic<G: GenericTokenAccount>(
         client: &mut Client,
         statement: &Statement,
         token_id: &Pubkey,
@@ -373,14 +331,14 @@ impl SimplePostgresClient {
         statement: &Statement,
         account: &DbAccountInfo,
     ) -> Result<(), AccountsDbPluginError> {
-        Self::update_token_owner_index_gen::<inline_spl_token::Account>(
+        Self::update_token_owner_index_generic::<inline_spl_token::Account>(
             client,
             statement,
             &inline_spl_token::id(),
             account,
         )?;
 
-        Self::update_token_owner_index_gen::<inline_spl_token_2022::Account>(
+        Self::update_token_owner_index_generic::<inline_spl_token_2022::Account>(
             client,
             statement,
             &inline_spl_token_2022::id(),
@@ -394,14 +352,14 @@ impl SimplePostgresClient {
         statement: &Statement,
         account: &DbAccountInfo,
     ) -> Result<(), AccountsDbPluginError> {
-        Self::update_token_mint_index_gen::<inline_spl_token::Account>(
+        Self::update_token_mint_index_generic::<inline_spl_token::Account>(
             client,
             statement,
             &inline_spl_token::id(),
             account,
         )?;
 
-        Self::update_token_mint_index_gen::<inline_spl_token_2022::Account>(
+        Self::update_token_mint_index_generic::<inline_spl_token_2022::Account>(
             client,
             statement,
             &inline_spl_token_2022::id(),

--- a/src/postgres_client/postgres_client_account_index.rs
+++ b/src/postgres_client/postgres_client_account_index.rs
@@ -33,7 +33,7 @@ impl SimplePostgresClient {
         config: &AccountsDbPluginPostgresConfig,
     ) -> Result<Statement, AccountsDbPluginError> {
         let stmt = "INSERT INTO spl_token_owner_index AS owner_index (owner_key, inner_key, slot) \
-        VALUES ($1, $2, $3) ON CONFLICT DO UPDATE SET slot=excluded.slot where owner_index.slot < excluded.slot";
+        VALUES ($1, $2, $3) ON CONFLICT (owner_key, inner_key) DO UPDATE SET slot=excluded.slot where owner_index.slot < excluded.slot";
 
         Self::prepare_query_statement(client, config, stmt)
     }
@@ -43,7 +43,7 @@ impl SimplePostgresClient {
         config: &AccountsDbPluginPostgresConfig,
     ) -> Result<Statement, AccountsDbPluginError> {
         let stmt = "INSERT INTO spl_token_mint_index AS mint_index (mint_key, inner_key, slot) \
-        VALUES ($1, $2, $3) ON CONFLICT DO UPDATE SET slot=excluded.slot where mint_index.slot < excluded.slot";
+        VALUES ($1, $2, $3) ON CONFLICT (owner_key, inner_key) DO UPDATE SET slot=excluded.slot where mint_index.slot < excluded.slot";
 
         Self::prepare_query_statement(client, config, stmt)
     }
@@ -71,7 +71,7 @@ impl SimplePostgresClient {
         }
 
         let handle_conflict =
-            "ON CONFLICT DO UPDATE SET slot=excluded.slot where index.slot < excluded.slot";
+            "ON CONFLICT (owner_key, inner_key) DO UPDATE SET slot=excluded.slot where index.slot < excluded.slot";
 
         stmt = format!("{} {}", stmt, handle_conflict);
 
@@ -114,7 +114,7 @@ impl SimplePostgresClient {
         }
 
         let handle_conflict =
-            "ON CONFLICT DO UPDATE SET slot=excluded.slot where index.slot < excluded.slot";
+            "ON CONFLICT (owner_key, inner_key) DO UPDATE SET slot=excluded.slot where index.slot < excluded.slot";
 
         stmt = format!("{} {}", stmt, handle_conflict);
 

--- a/src/postgres_client/postgres_client_account_index.rs
+++ b/src/postgres_client/postgres_client_account_index.rs
@@ -50,7 +50,8 @@ impl SimplePostgresClient {
             }
         }
 
-        let handle_conflict = "ON CONFLICT DO UPDATE SET slot=excluded.slot where index.slot < excluded.slot";
+        let handle_conflict =
+            "ON CONFLICT DO UPDATE SET slot=excluded.slot where index.slot < excluded.slot";
 
         stmt = format!("{} {}", stmt, handle_conflict);
 
@@ -78,8 +79,9 @@ impl SimplePostgresClient {
         let batch_size = config
             .batch_size
             .unwrap_or(DEFAULT_ACCOUNTS_INSERT_BATCH_SIZE);
-        let mut stmt =
-            String::from("INSERT INTO spl_token_mint_index AS index (mint_key, inner_key, slot) VALUES");
+        let mut stmt = String::from(
+            "INSERT INTO spl_token_mint_index AS index (mint_key, inner_key, slot) VALUES",
+        );
         for j in 0..batch_size {
             let row = j * TOKEN_INDEX_COLUMN_COUNT;
             let val_str = format!("(${}, ${}, ${})", row + 1, row + 2, row + 3);
@@ -91,7 +93,8 @@ impl SimplePostgresClient {
             }
         }
 
-        let handle_conflict = "ON CONFLICT DO UPDATE SET slot=excluded.slot where index.slot < excluded.slot";
+        let handle_conflict =
+            "ON CONFLICT DO UPDATE SET slot=excluded.slot where index.slot < excluded.slot";
 
         stmt = format!("{} {}", stmt, handle_conflict);
 
@@ -240,7 +243,7 @@ impl SimplePostgresClient {
                 self.pending_token_owner_index.push(TokenSecondaryIndex {
                     owner: owner_key,
                     inner_key: pubkey.to_vec(),
-                    slot: account.slot
+                    slot: account.slot,
                 });
             }
         }
@@ -259,7 +262,7 @@ impl SimplePostgresClient {
                 self.pending_token_mint_index.push(TokenSecondaryIndex {
                     owner: mint_key,
                     inner_key: pubkey.to_vec(),
-                    slot: account.slot
+                    slot: account.slot,
                 })
             }
         }

--- a/src/postgres_client/postgres_client_account_index.rs
+++ b/src/postgres_client/postgres_client_account_index.rs
@@ -1,0 +1,366 @@
+use {
+    super::{
+        DbAccountInfo, ReadableAccountInfo, SimplePostgresClient,
+        DEFAULT_ACCOUNTS_INSERT_BATCH_SIZE,
+    },
+    crate::{
+        accountsdb_plugin_postgres::{
+            AccountsDbPluginPostgresConfig, AccountsDbPluginPostgresError,
+        },
+        inline_spl_token::{self, GenericTokenAccount},
+        inline_spl_token_2022,
+    },
+    log::*,
+    postgres::{Client, Statement},
+    solana_accountsdb_plugin_interface::accountsdb_plugin_interface::AccountsDbPluginError,
+    solana_measure::measure::Measure,
+    solana_metrics::*,
+    solana_sdk::pubkey::Pubkey,
+    tokio_postgres::types,
+};
+
+const TOKEN_IDX_COLUMN_COUNT: usize = 2;
+/// Model the secondary index for token owner and mint
+pub struct TokenSecondaryIndex {
+    owner: Vec<u8>,
+    inner_key: Vec<u8>,
+}
+
+impl SimplePostgresClient {
+    pub fn build_bulk_token_owner_index_insert_statement(
+        client: &mut Client,
+        config: &AccountsDbPluginPostgresConfig,
+    ) -> Result<Statement, AccountsDbPluginError> {
+        let batch_size = config
+            .batch_size
+            .unwrap_or(DEFAULT_ACCOUNTS_INSERT_BATCH_SIZE);
+        let mut stmt =
+            String::from("INSERT INTO spl_token_owner_index AS idx (owner_key, inner_key) VALUES");
+        for j in 0..batch_size {
+            let row = j * TOKEN_IDX_COLUMN_COUNT;
+            let val_str = format!("(${}, ${})", row + 1, row + 2,);
+
+            if j == 0 {
+                stmt = format!("{} {}", &stmt, val_str);
+            } else {
+                stmt = format!("{}, {}", &stmt, val_str);
+            }
+        }
+
+        let handle_conflict = "ON CONFLICT DO NOTHING";
+
+        stmt = format!("{} {}", stmt, handle_conflict);
+
+        info!("{}", stmt);
+        let bulk_stmt = client.prepare(&stmt);
+
+        match bulk_stmt {
+            Err(err) => {
+                return Err(AccountsDbPluginError::Custom(Box::new(AccountsDbPluginPostgresError::DataSchemaError {
+                    msg: format!(
+                        "Error in preparing for the token owner index update PostgreSQL database: {} host: {:?} user: {:?} config: {:?}",
+                        err, config.host, config.user, config
+                    ),
+                })));
+            }
+            Ok(update_account_stmt) => Ok(update_account_stmt),
+        }
+    }
+
+    pub fn build_bulk_token_mint_index_insert_statement(
+        client: &mut Client,
+        config: &AccountsDbPluginPostgresConfig,
+    ) -> Result<Statement, AccountsDbPluginError> {
+        let batch_size = config
+            .batch_size
+            .unwrap_or(DEFAULT_ACCOUNTS_INSERT_BATCH_SIZE);
+        let mut stmt =
+            String::from("INSERT INTO spl_token_mint_index AS idx (mint_key, inner_key) VALUES");
+        for j in 0..batch_size {
+            let row = j * TOKEN_IDX_COLUMN_COUNT;
+            let val_str = format!("(${}, ${})", row + 1, row + 2,);
+
+            if j == 0 {
+                stmt = format!("{} {}", &stmt, val_str);
+            } else {
+                stmt = format!("{}, {}", &stmt, val_str);
+            }
+        }
+
+        let handle_conflict = "ON CONFLICT DO NOTHING";
+
+        stmt = format!("{} {}", stmt, handle_conflict);
+
+        info!("{}", stmt);
+        let bulk_stmt = client.prepare(&stmt);
+
+        match bulk_stmt {
+            Err(err) => {
+                return Err(AccountsDbPluginError::Custom(Box::new(AccountsDbPluginPostgresError::DataSchemaError {
+                    msg: format!(
+                        "Error in preparing for the token mint index update PostgreSQL database: {} host: {:?} user: {:?} config: {:?}",
+                        err, config.host, config.user, config
+                    ),
+                })));
+            }
+            Ok(update_account_stmt) => Ok(update_account_stmt),
+        }
+    }
+
+    pub fn bulk_insert_token_owner_idx(&mut self) -> Result<(), AccountsDbPluginError> {
+        if self.pending_token_owner_idx.len() == self.batch_size {
+            let mut measure = Measure::start("accountsdb-plugin-postgres-prepare-owner-idx-values");
+
+            let mut values: Vec<&(dyn types::ToSql + Sync)> =
+                Vec::with_capacity(self.batch_size * TOKEN_IDX_COLUMN_COUNT);
+            for j in 0..self.batch_size {
+                let index = &self.pending_token_owner_idx[j];
+                values.push(&index.owner);
+                values.push(&index.inner_key);
+            }
+            measure.stop();
+            inc_new_counter_debug!(
+                "accountsdb-plugin-postgres-prepare-owner-idx-values-us",
+                measure.as_us() as usize,
+                10000,
+                10000
+            );
+
+            let mut measure = Measure::start("accountsdb-plugin-postgres-update-owner-idx-account");
+            let client = self.client.get_mut().unwrap();
+            let result = client.client.query(
+                client.bulk_insert_token_owner_idx_stmt.as_ref().unwrap(),
+                &values,
+            );
+
+            self.pending_token_owner_idx.clear();
+
+            if let Err(err) = result {
+                let msg = format!(
+                    "Failed to persist the update of account to the PostgreSQL database. Error: {:?}",
+                    err
+                );
+                error!("{}", msg);
+                return Err(AccountsDbPluginError::AccountsUpdateError { msg });
+            }
+
+            measure.stop();
+            inc_new_counter_debug!(
+                "accountsdb-plugin-postgres-update-owner-idx-us",
+                measure.as_us() as usize,
+                10000,
+                10000
+            );
+            inc_new_counter_debug!(
+                "accountsdb-plugin-postgres-update-owner-idx-count",
+                self.batch_size,
+                10000,
+                10000
+            );
+        }
+        Ok(())
+    }
+
+    pub fn bulk_insert_token_mint_idx(&mut self) -> Result<(), AccountsDbPluginError> {
+        if self.pending_token_owner_idx.len() == self.batch_size {
+            let mut measure = Measure::start("accountsdb-plugin-postgres-prepare-mint-idx-values");
+
+            let mut values: Vec<&(dyn types::ToSql + Sync)> =
+                Vec::with_capacity(self.batch_size * TOKEN_IDX_COLUMN_COUNT);
+            for j in 0..self.batch_size {
+                let index = &self.pending_token_mint_idx[j];
+                values.push(&index.owner);
+                values.push(&index.inner_key);
+            }
+            measure.stop();
+            inc_new_counter_debug!(
+                "accountsdb-plugin-postgres-prepare-mint-idx-values-us",
+                measure.as_us() as usize,
+                10000,
+                10000
+            );
+
+            let mut measure = Measure::start("accountsdb-plugin-postgres-update-mint-idx-account");
+            let client = self.client.get_mut().unwrap();
+            let result = client.client.query(
+                client.bulk_insert_token_mint_idx_stmt.as_ref().unwrap(),
+                &values,
+            );
+
+            self.pending_token_mint_idx.clear();
+
+            if let Err(err) = result {
+                let msg = format!(
+                    "Failed to persist the update of account to the PostgreSQL database. Error: {:?}",
+                    err
+                );
+                error!("{}", msg);
+                return Err(AccountsDbPluginError::AccountsUpdateError { msg });
+            }
+
+            measure.stop();
+            inc_new_counter_debug!(
+                "accountsdb-plugin-postgres-update-mint-idx-us",
+                measure.as_us() as usize,
+                10000,
+                10000
+            );
+            inc_new_counter_debug!(
+                "accountsdb-plugin-postgres-update-mint-idx-count",
+                self.batch_size,
+                10000,
+                10000
+            );
+        }
+        Ok(())
+    }
+
+    fn queue_token_owner_idx_gen<G: GenericTokenAccount>(
+        &mut self,
+        token_id: &Pubkey,
+        account: &DbAccountInfo,
+    ) {
+        if account.owner() == token_id.to_bytes() {
+            if let Some(owner_key) = G::unpack_account_owner(account.data()) {
+                let owner_key = owner_key.to_bytes().to_vec();
+                let pubkey = account.pubkey();
+                self.pending_token_owner_idx.push(TokenSecondaryIndex {
+                    owner: owner_key,
+                    inner_key: pubkey.to_vec(),
+                });
+            }
+        }
+    }
+
+    fn queue_token_mint_idx_gen<G: GenericTokenAccount>(
+        &mut self,
+        token_id: &Pubkey,
+        account: &DbAccountInfo,
+    ) {
+        if account.owner() == token_id.to_bytes() {
+            if let Some(mint_key) = G::unpack_account_mint(account.data()) {
+                let mint_key = mint_key.to_bytes().to_vec();
+                let pubkey = account.pubkey();
+                self.pending_token_mint_idx.push(TokenSecondaryIndex {
+                    owner: mint_key,
+                    inner_key: pubkey.to_vec(),
+                })
+            }
+        }
+    }
+
+    /// Queue bulk insert secondary indexes
+    pub fn queue_secondary_indexes(&mut self, account: &DbAccountInfo) {
+        if self.index_token_owner {
+            self.queue_token_owner_idx_gen::<inline_spl_token::Account>(
+                &inline_spl_token::id(),
+                account,
+            );
+            self.queue_token_owner_idx_gen::<inline_spl_token_2022::Account>(
+                &inline_spl_token_2022::id(),
+                account,
+            );
+        }
+
+        if self.index_token_mint {
+            self.queue_token_mint_idx_gen::<inline_spl_token::Account>(
+                &inline_spl_token::id(),
+                account,
+            );
+            self.queue_token_mint_idx_gen::<inline_spl_token_2022::Account>(
+                &inline_spl_token_2022::id(),
+                account,
+            );
+        }
+    }
+
+    fn update_token_owner_idx_gen<G: GenericTokenAccount>(
+        client: &mut Client,
+        statement: &Statement,
+        token_id: &Pubkey,
+        account: &DbAccountInfo,
+    ) -> Result<(), AccountsDbPluginError> {
+        if account.owner() == token_id.to_bytes() {
+            if let Some(owner_key) = G::unpack_account_owner(account.data()) {
+                let owner_key = owner_key.to_bytes().to_vec();
+                let pubkey = account.pubkey();
+                let result = client.execute(statement, &[&owner_key, &pubkey]);
+                if let Err(err) = result {
+                    let msg = format!(
+                        "Failed to update the token owner index to the PostgreSQL database. Error: {:?}",
+                        err
+                    );
+                    error!("{}", msg);
+                    return Err(AccountsDbPluginError::AccountsUpdateError { msg });
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn update_token_mint_idx_gen<G: GenericTokenAccount>(
+        client: &mut Client,
+        statement: &Statement,
+        token_id: &Pubkey,
+        account: &DbAccountInfo,
+    ) -> Result<(), AccountsDbPluginError> {
+        if account.owner() == token_id.to_bytes() {
+            if let Some(mint_key) = G::unpack_account_mint(account.data()) {
+                let mint_key = mint_key.to_bytes().to_vec();
+                let pubkey = account.pubkey();
+                let result = client.execute(statement, &[&mint_key, &pubkey]);
+                if let Err(err) = result {
+                    let msg = format!(
+                        "Failed to update the token mint index to the PostgreSQL database. Error: {:?}",
+                        err
+                    );
+                    error!("{}", msg);
+                    return Err(AccountsDbPluginError::AccountsUpdateError { msg });
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn update_token_owner_idx(
+        client: &mut Client,
+        statement: &Statement,
+        account: &DbAccountInfo,
+    ) -> Result<(), AccountsDbPluginError> {
+        Self::update_token_owner_idx_gen::<inline_spl_token::Account>(
+            client,
+            statement,
+            &inline_spl_token::id(),
+            account,
+        )?;
+
+        Self::update_token_owner_idx_gen::<inline_spl_token_2022::Account>(
+            client,
+            statement,
+            &inline_spl_token_2022::id(),
+            account,
+        )
+    }
+
+    pub fn update_token_mint_idx(
+        client: &mut Client,
+        statement: &Statement,
+        account: &DbAccountInfo,
+    ) -> Result<(), AccountsDbPluginError> {
+        Self::update_token_mint_idx_gen::<inline_spl_token::Account>(
+            client,
+            statement,
+            &inline_spl_token::id(),
+            account,
+        )?;
+
+        Self::update_token_mint_idx_gen::<inline_spl_token_2022::Account>(
+            client,
+            statement,
+            &inline_spl_token_2022::id(),
+            account,
+        )
+    }
+}


### PR DESCRIPTION
Persisting token owner index and token mint index if configured so.
Do bulk insert during startup
Persist during accounts update due to transaction.