### PR TITLE
Drop table account in cascade

### DIFF
--- a/scripts/drop_schema.sql
+++ b/scripts/drop_schema.sql
@@ -5,7 +5,7 @@
 DROP TRIGGER account_update_trigger ON account;
 DROP FUNCTION audit_account_update;
 DROP TABLE account_audit;
-DROP TABLE account;
+DROP TABLE account CASCADE;
 DROP TABLE slot;
 DROP TABLE transaction;
 DROP TABLE block;


### PR DESCRIPTION
The drop failed due to other added functions using it. Use cascade.