### PR TITLE
feat: optionaly speed up batch insertion when validator is started

### DIFF
--- a/src/geyser_plugin_postgres.rs
+++ b/src/geyser_plugin_postgres.rs
@@ -24,7 +24,7 @@ pub struct GeyserPluginPostgres {
     client: Option<ParallelPostgresClient>,
     accounts_selector: Option<AccountsSelector>,
     transaction_selector: Option<TransactionSelector>,
-    batch_optimize_by_skiping_older_slots: Option<u64>,
+    batch_starting_slot: Option<u64>,
 }
 
 impl std::fmt::Debug for GeyserPluginPostgres {
@@ -192,7 +192,7 @@ impl GeyserPlugin for GeyserPluginPostgres {
         let (client, batch_optimize_by_skiping_older_slots) =
             PostgresClientBuilder::build_pararallel_postgres_client(&config)?;
         self.client = Some(client);
-        self.batch_optimize_by_skiping_older_slots = batch_optimize_by_skiping_older_slots;
+        self.batch_starting_slot = batch_optimize_by_skiping_older_slots;
 
         Ok(())
     }
@@ -218,7 +218,7 @@ impl GeyserPlugin for GeyserPluginPostgres {
         // is configured
         if is_startup
             && self
-                .batch_optimize_by_skiping_older_slots
+                .batch_starting_slot
                 .map(|slot_limit| slot < slot_limit)
                 .unwrap_or(false)
         {

--- a/src/geyser_plugin_postgres.rs
+++ b/src/geyser_plugin_postgres.rs
@@ -81,6 +81,10 @@ pub struct GeyserPluginPostgresConfig {
 
     /// Controls whetherf to index the token mints. The default is false
     pub index_token_mint: Option<bool>,
+
+    /// Controls if this plugin can read the database on_load() and find slot below that one everything should be in database
+    #[serde(default)]
+    pub batch_optimize_by_skiping_old_slots: bool,
 }
 
 #[derive(Error, Debug)]

--- a/src/postgres_client.rs
+++ b/src/postgres_client.rs
@@ -844,7 +844,7 @@ impl SimplePostgresClient {
     fn get_highest_available_slot(&mut self) -> Result<u64, GeyserPluginError> {
         let client = self.client.get_mut().unwrap();
 
-        let last_slot_query = "SELECT slot FROM public.slot ORDER BY slot DESC LIMIT 1;";
+        let last_slot_query = "SELECT slot FROM slot ORDER BY slot DESC LIMIT 1;";
 
         let result = client.client.query_opt(last_slot_query, &[]);
         match result {
@@ -1266,7 +1266,6 @@ impl PostgresClientBuilder {
         let batch_optimize_by_skiping_older_slots = match config.batch_optimize_by_skiping_old_slots
         {
             true => {
-                //one request client
                 let mut on_load_client = SimplePostgresClient::new(config)?;
 
                 let max_queue_size = u64::try_from(MAX_ASYNC_REQUESTS).unwrap();


### PR DESCRIPTION
- This plugin make validator startup a few times longer. This PR proposition could improve this by skipping insertion of accounts that we can assume were already inserted.
- remove unused function `build_simple_postgres_client`