### PR TITLE
fix: insert slot status at startup batch size condition

### DIFF
--- a/src/postgres_client.rs
+++ b/src/postgres_client.rs
@@ -671,10 +671,6 @@ impl SimplePostgresClient {
 
     /// Flush any left over accounts in batch which are not processed in the last batch
     fn flush_buffered_writes(&mut self) -> Result<(), GeyserPluginError> {
-        if self.pending_account_updates.is_empty() {
-            return Ok(());
-        }
-
         let client = self.client.get_mut().unwrap();
         let insert_account_audit_stmt = &client.insert_account_audit_stmt;
         let statement = &client.update_account_stmt;


### PR DESCRIPTION
`self.pending_account_updates` can be empty for example because of[ this condition](https://github.com/solana-labs/solana-accountsdb-plugin-postgres/blob/736d3f98d8aa0f8da2219ece2d692fba54dbd168/src/postgres_client.rs#L644). And there is still need to push `slots_at_startup` to database. 