### PR TITLE
Handle new ReplicaTransactionInfoV2 version

### DIFF
--- a/scripts/create_schema.sql
+++ b/scripts/create_schema.sql
@@ -166,7 +166,7 @@ CREATE TABLE transaction (
     message_hash BYTEA,
     meta "TransactionStatusMeta",
     write_version BIGINT,
-    index BIGINT NOT NULL,
+    index BIGINT,
     updated_on TIMESTAMP NOT NULL,
     CONSTRAINT transaction_pk PRIMARY KEY (slot, signature)
 );

--- a/scripts/create_schema.sql
+++ b/scripts/create_schema.sql
@@ -166,6 +166,7 @@ CREATE TABLE transaction (
     message_hash BYTEA,
     meta "TransactionStatusMeta",
     write_version BIGINT,
+    index BIGINT NOT NULL,
     updated_on TIMESTAMP NOT NULL,
     CONSTRAINT transaction_pk PRIMARY KEY (slot, signature)
 );

--- a/src/geyser_plugin_postgres.rs
+++ b/src/geyser_plugin_postgres.rs
@@ -378,6 +378,26 @@ impl GeyserPlugin for GeyserPluginPostgres {
                             });
                     }
                 }
+                ReplicaTransactionInfoVersions::V0_0_2(transaction_info) => {
+                    if let Some(transaction_selector) = &self.transaction_selector {
+                        if !transaction_selector.is_transaction_selected(
+                            transaction_info.is_vote,
+                            Box::new(transaction_info.transaction.message().account_keys().iter()),
+                        ) {
+                            return Ok(());
+                        }
+                    } else {
+                        return Ok(());
+                    }
+
+                    let result = client.log_transaction_info_v2(transaction_info, slot);
+
+                    if let Err(err) = result {
+                        return Err(GeyserPluginError::SlotStatusUpdateError{
+                                msg: format!("Failed to persist the transaction info to the PostgreSQL database. Error: {:?}", err)
+                            });
+                    }
+                }
             },
         }
 

--- a/src/postgres_client/postgres_client_transaction.rs
+++ b/src/postgres_client/postgres_client_transaction.rs
@@ -572,8 +572,8 @@ impl SimplePostgresClient {
         config: &GeyserPluginPostgresConfig,
     ) -> Result<Statement, GeyserPluginError> {
         let stmt = "INSERT INTO transaction AS txn (signature, is_vote, slot, message_type, legacy_message, \
-        v0_loaded_message, signatures, message_hash, meta, write_version, updated_on) \
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11) \
+        v0_loaded_message, signatures, message_hash, meta, write_version, index, updated_on) \
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12) \
         ON CONFLICT (slot, signature) DO UPDATE SET is_vote=excluded.is_vote, \
         message_type=excluded.message_type, \
         legacy_message=excluded.legacy_message, \
@@ -613,6 +613,7 @@ impl SimplePostgresClient {
             statement,
             &[
                 &transaction_info.signature,
+                &transaction_info.index,
                 &transaction_info.is_vote,
                 &transaction_info.slot,
                 &transaction_info.message_type,

--- a/src/postgres_client/postgres_client_transaction.rs
+++ b/src/postgres_client/postgres_client_transaction.rs
@@ -582,6 +582,7 @@ impl SimplePostgresClient {
         message_hash=excluded.message_hash, \
         meta=excluded.meta, \
         write_version=excluded.write_version, \
+        index=excluded.index, \
         updated_on=excluded.updated_on";
 
         let stmt = client.prepare(stmt);

--- a/src/postgres_client/postgres_client_transaction.rs
+++ b/src/postgres_client/postgres_client_transaction.rs
@@ -10,7 +10,7 @@ use {
     postgres::{Client, Statement},
     postgres_types::{FromSql, ToSql},
     solana_geyser_plugin_interface::geyser_plugin_interface::{
-        GeyserPluginError, ReplicaTransactionInfo,
+        GeyserPluginError, ReplicaTransactionInfo, ReplicaTransactionInfoV2,
     },
     solana_runtime::bank::RewardType,
     solana_sdk::{
@@ -149,6 +149,7 @@ pub struct DbTransaction {
     /// Given a slot, the transaction with a smaller write_version appears
     /// before transactions with higher write_versions in a shred.
     pub write_version: i64,
+    pub index: i64,
 }
 
 pub struct LogTransactionRequest {
@@ -521,6 +522,47 @@ fn build_db_transaction(
             .to_vec(),
         meta: DbTransactionStatusMeta::from(transaction_info.transaction_status_meta),
         write_version: transaction_write_version as i64,
+        index: 0,
+    }
+}
+
+fn build_db_transaction_v2(
+    slot: u64,
+    transaction_info: &ReplicaTransactionInfoV2,
+    transaction_write_version: u64,
+) -> DbTransaction {
+    DbTransaction {
+        signature: transaction_info.signature.as_ref().to_vec(),
+        is_vote: transaction_info.is_vote,
+        slot: slot as i64,
+        message_type: match transaction_info.transaction.message() {
+            SanitizedMessage::Legacy(_) => 0,
+            SanitizedMessage::V0(_) => 1,
+        },
+        legacy_message: match transaction_info.transaction.message() {
+            SanitizedMessage::Legacy(legacy_message) => {
+                Some(DbTransactionMessage::from(legacy_message))
+            }
+            _ => None,
+        },
+        v0_loaded_message: match transaction_info.transaction.message() {
+            SanitizedMessage::V0(loaded_message) => Some(DbLoadedMessageV0::from(loaded_message)),
+            _ => None,
+        },
+        signatures: transaction_info
+            .transaction
+            .signatures()
+            .iter()
+            .map(|signature| signature.as_ref().to_vec())
+            .collect(),
+        message_hash: transaction_info
+            .transaction
+            .message_hash()
+            .as_ref()
+            .to_vec(),
+        meta: DbTransactionStatusMeta::from(transaction_info.transaction_status_meta),
+        write_version: transaction_write_version as i64,
+        index: transaction_info.index as i64,
     }
 }
 
@@ -612,6 +654,20 @@ impl ParallelPostgresClient {
         }
     }
 
+    fn build_transaction_request_v2(
+        slot: u64,
+        transaction_info: &ReplicaTransactionInfoV2,
+        transaction_write_version: u64,
+    ) -> LogTransactionRequest {
+        LogTransactionRequest {
+            transaction_info: build_db_transaction_v2(
+                slot,
+                transaction_info,
+                transaction_write_version,
+            ),
+        }
+    }
+
     pub fn log_transaction_info(
         &mut self,
         transaction_info: &ReplicaTransactionInfo,
@@ -620,6 +676,27 @@ impl ParallelPostgresClient {
         self.transaction_write_version
             .fetch_add(1, Ordering::Relaxed);
         let wrk_item = DbWorkItem::LogTransaction(Box::new(Self::build_transaction_request(
+            slot,
+            transaction_info,
+            self.transaction_write_version.load(Ordering::Relaxed),
+        )));
+
+        if let Err(err) = self.sender.send(wrk_item) {
+            return Err(GeyserPluginError::SlotStatusUpdateError {
+                msg: format!("Failed to update the transaction, error: {:?}", err),
+            });
+        }
+        Ok(())
+    }
+
+    pub fn log_transaction_info_v2(
+        &mut self,
+        transaction_info: &ReplicaTransactionInfoV2,
+        slot: u64,
+    ) -> Result<(), GeyserPluginError> {
+        self.transaction_write_version
+            .fetch_add(1, Ordering::Relaxed);
+        let wrk_item = DbWorkItem::LogTransaction(Box::new(Self::build_transaction_request_v2(
             slot,
             transaction_info,
             self.transaction_write_version.load(Ordering::Relaxed),


### PR DESCRIPTION
Adds `index` field to `transaction` table schema.
Populates index from ReplicaTransactionInfoV2 (or defaults to zero)

Like #28, this depends on an update to solana v1.11