### PR TITLE
Change default thread count from 100 to 10.

### DIFF
--- a/src/postgres_client.rs
+++ b/src/postgres_client.rs
@@ -40,7 +40,7 @@ use {
 /// memory usage. The downside -- calls after this threshold is reached can get blocked.
 const MAX_ASYNC_REQUESTS: usize = 40960;
 const DEFAULT_POSTGRES_PORT: u16 = 5432;
-const DEFAULT_THREADS_COUNT: usize = 100;
+const DEFAULT_THREADS_COUNT: usize = 10;
 const DEFAULT_ACCOUNTS_INSERT_BATCH_SIZE: usize = 10;
 const ACCOUNT_COLUMN_COUNT: usize = 10;
 const DEFAULT_PANIC_ON_DB_ERROR: bool = false;


### PR DESCRIPTION
- Fixes default thread count from `100` to `10`, as initially specified in code comments.

From the code comments:
```
/// * "threads" optional, specifies the number of worker threads for the plugin. A thread
/// maintains a PostgreSQL connection to the server. The default is '10'.
```