### PR TITLE
chore: rename config parameter from batch_optimize_by_skiping_old_slot -> skip_upsert_existing_accounts_at_startup

### DIFF
--- a/src/geyser_plugin_postgres.rs
+++ b/src/geyser_plugin_postgres.rs
@@ -83,9 +83,10 @@ pub struct GeyserPluginPostgresConfig {
     /// Controls whetherf to index the token mints. The default is false
     pub index_token_mint: Option<bool>,
 
-    /// Controls if this plugin can read the database on_load() and find slot below that one everything should be in database
+    /// Controls if this plugin can read the database on_load() to find heighest slot
+    /// and ignore upsetr accounts (at_startup) that should already exist in DB
     #[serde(default)]
-    pub batch_optimize_by_skiping_old_slots: bool,
+    pub skip_upsert_existing_accounts_at_startup: bool,
 }
 
 #[derive(Error, Debug)]

--- a/src/postgres_client.rs
+++ b/src/postgres_client.rs
@@ -1280,24 +1280,24 @@ impl PostgresClientBuilder {
     pub fn build_pararallel_postgres_client(
         config: &GeyserPluginPostgresConfig,
     ) -> Result<(ParallelPostgresClient, Option<u64>), GeyserPluginError> {
-        let batch_optimize_by_skiping_older_slots = match config.batch_optimize_by_skiping_old_slots
-        {
-            true => {
-                let mut on_load_client = SimplePostgresClient::new(config)?;
+        let batch_optimize_by_skiping_older_slots =
+            match config.skip_upsert_existing_accounts_at_startup {
+                true => {
+                    let mut on_load_client = SimplePostgresClient::new(config)?;
 
-                // database if populated concurrently so we need to move some number of slots
-                // below highest available slot to make sure we do not skip anything that was already in DB.
-                let batch_slot_bound = on_load_client
-                    .get_highest_available_slot()?
-                    .saturating_sub(SAFE_BATCH_STARTING_SLOT_CUSHION);
-                info!(
-                    "Set batch_optimize_by_skiping_older_slots to {}",
-                    batch_slot_bound
-                );
-                Some(batch_slot_bound)
-            }
-            false => None,
-        };
+                    // database if populated concurrently so we need to move some number of slots
+                    // below highest available slot to make sure we do not skip anything that was already in DB.
+                    let batch_slot_bound = on_load_client
+                        .get_highest_available_slot()?
+                        .saturating_sub(SAFE_BATCH_STARTING_SLOT_CUSHION);
+                    info!(
+                        "Set batch_optimize_by_skiping_older_slots to {}",
+                        batch_slot_bound
+                    );
+                    Some(batch_slot_bound)
+                }
+                false => None,
+            };
 
         ParallelPostgresClient::new(config).map(|v| (v, batch_optimize_by_skiping_older_slots))
     }


### PR DESCRIPTION
This just use better name to describe what this option actually doing. This is related to: #26