### PR TITLE
Use 1.13.1 version of all dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,20 +18,20 @@ bytemuck = "1.7.2"
 chrono = { version = "0.4.11", features = ["serde"] }
 crossbeam-channel = "0.5"
 log = "0.4.14"
-openssl = { version = "0.10" }
+openssl = { version = "0.10"}
 postgres = { version = "0.19.2", features = ["with-chrono-0_4"] }
 postgres-types = { version = "0.2.2", features = ["derive"] }
 postgres-openssl = { version = "0.5.0"}
 serde = "1.0.133"
 serde_derive = "1.0.103"
 serde_json = "1.0.74"
-solana-geyser-plugin-interface = { version = "=1.11.1" }
-solana-logger = { version = "=1.11.1" }
-solana-measure = { version = "=1.11.1" }
-solana-metrics = { version = "=1.11.1" }
-solana-runtime = { version = "=1.11.1" }
-solana-sdk = { version = "=1.11.1" }
-solana-transaction-status = { version = "=1.11.1" }
+solana-geyser-plugin-interface = { version = "=1.13.1" }
+solana-logger = { version = "=1.13.1" }
+solana-measure = { version = "=1.13.1" }
+solana-metrics = { version = "=1.13.1" }
+solana-runtime = { version = "=1.13.1" }
+solana-sdk = { version = "=1.13.1" }
+solana-transaction-status = { version = "=1.13.1" }
 thiserror = "1.0.30"
 tokio-postgres = "0.7.4"
 
@@ -39,11 +39,11 @@ tokio-postgres = "0.7.4"
 libc = "0.2.112"
 libloading = "0.7.2"
 serial_test = "0.5.1"
-solana-account-decoder = { version = "=1.11.1" }
-solana-core = { version = "=1.11.1" }
-solana-local-cluster = { version = "=1.11.1" }
-solana-net-utils = { version = "=1.11.1" }
-solana-streamer = { version = "=1.11.1" }
+solana-account-decoder = { version = "=1.13.1" }
+solana-core = { version = "=1.13.1" }
+solana-local-cluster = { version = "=1.13.1" }
+solana-net-utils = { version = "=1.13.1" }
+solana-streamer = { version = "=1.13.1" }
 tempfile = "3.2.0"
 
 [package.metadata.docs.rs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-geyser-plugin-postgres"
 description = "The Solana AccountsDb plugin for PostgreSQL database."
-version = "1.11.1"
+version = "1.13.1"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -18,7 +18,7 @@ bytemuck = "1.7.2"
 chrono = { version = "0.4.11", features = ["serde"] }
 crossbeam-channel = "0.5"
 log = "0.4.14"
-openssl = { version = "0.10"}
+openssl = { version = "0.10" }
 postgres = { version = "0.19.2", features = ["with-chrono-0_4"] }
 postgres-types = { version = "0.2.2", features = ["derive"] }
 postgres-openssl = { version = "0.5.0"}


### PR DESCRIPTION
Just opening a PR in case this could help anyone, solves issue #42 when using solana CLI version 1.13.2.

Could also include line 21 in Cargo.toml as `openssl = { version = "0.10", features = ["vendored"] }` for other users on M1, but I think this would cause everyone to recompile openssl so I didn't include that change.