### PR TITLE
Bump to solana 1.14.16; add changes to be compatible with solana_sdk changes in 1.14.16 solana release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 edition = "2021"
 name = "solana-geyser-plugin-postgres"
 description = "The Solana AccountsDb plugin for PostgreSQL database."
-version = "1.14.10"
+version = "1.14.16"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -25,13 +25,13 @@ postgres-openssl = { version = "0.5.0"}
 serde = "1.0.145"
 serde_derive = "1.0.145"
 serde_json = "1.0.85"
-solana-geyser-plugin-interface = { version = "=1.14.10" }
-solana-logger = { version = "=1.14.10" }
-solana-measure = { version = "=1.14.10" }
-solana-metrics = { version = "=1.14.10" }
-solana-runtime = { version = "=1.14.10" }
-solana-sdk = { version = "=1.14.10" }
-solana-transaction-status = { version = "=1.14.10" }
+solana-geyser-plugin-interface = { version = "=1.14.16" }
+solana-logger = { version = "=1.14.16" }
+solana-measure = { version = "=1.14.16" }
+solana-metrics = { version = "=1.14.16" }
+solana-runtime = { version = "=1.14.16" }
+solana-sdk = { version = "=1.14.16" }
+solana-transaction-status = { version = "=1.14.16" }
 thiserror = "1.0.37"
 tokio-postgres = "0.7.7"
 
@@ -41,11 +41,11 @@ libloading = "0.7.3"
 serial_test = "0.9.0"
 socket2 = { version = "0.4.7", features = ["all"] }
 
-solana-account-decoder = { version = "=1.14.10" }
-solana-core = { version = "=1.14.10" }
-solana-local-cluster = { version = "=1.14.10" }
-solana-net-utils = { version = "=1.14.10" }
-solana-streamer = { version = "=1.14.10" }
+solana-account-decoder = { version = "=1.14.16" }
+solana-core = { version = "=1.14.16" }
+solana-local-cluster = { version = "=1.14.16" }
+solana-net-utils = { version = "=1.14.16" }
+solana-streamer = { version = "=1.14.16" }
 tempfile = "3.3.0"
 
 [package.metadata.docs.rs]

--- a/src/postgres_client/postgres_client_transaction.rs
+++ b/src/postgres_client/postgres_client_transaction.rs
@@ -10,7 +10,7 @@ use {
     postgres::{Client, Statement},
     postgres_types::{FromSql, ToSql},
     solana_geyser_plugin_interface::geyser_plugin_interface::{
-        GeyserPluginError, ReplicaTransactionInfoV2,
+        GeyserPluginError, ReplicaTransactionInfoV2, LegacyMessage
     },
     solana_runtime::bank::RewardType,
     solana_sdk::{
@@ -234,6 +234,27 @@ impl From<&Message> for DbTransactionMessage {
     }
 }
 
+impl From<&LegacyMessage<'_>> for DbTransactionMessage {
+    fn from(message: &LegacyMessage) -> Self {
+        Self {
+            header: DbTransactionMessageHeader::from(&message.message.header),
+            account_keys: message
+                .message
+                .account_keys
+                .iter()
+                .map(|key| key.as_ref().to_vec())
+                .collect(),
+            recent_blockhash: message.message.recent_blockhash.as_ref().to_vec(),
+            instructions: message
+                .message
+                .instructions
+                .iter()
+                .map(DbCompiledInstruction::from)
+                .collect(),
+        }
+    }
+}
+   
 impl From<&v0::Message> for DbTransactionMessageV0 {
     fn from(message: &v0::Message) -> Self {
         Self {


### PR DESCRIPTION
Following changes are implemented:
- Bump Cargo.toml dependencies to Solana 1.14.16
- Add required compatibility changes to `src/postgres_client/postgres_client_transaction.rs` due to internal solana_sdk changes related to https://github.com/solana-labs/solana/commit/081ceb094577b3c84350c8804765250c318595bb
